### PR TITLE
security: fix remaining P0–P3 vulnerabilities from audit report

### DIFF
--- a/server/auth/__init__.py
+++ b/server/auth/__init__.py
@@ -1,0 +1,26 @@
+# Re-export public auth API so that `from . import auth` in main.py can reach
+# all symbols via `auth.<symbol>` without knowing the internal module layout.
+
+from .dependencies import get_current_user
+from .service import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    generate_salt,
+    hash_password,
+    verify_password,
+)
+
+# Legacy alias: some call sites use auth.get_password_hash
+get_password_hash = hash_password
+
+__all__ = [
+    "create_access_token",
+    "create_refresh_token",
+    "decode_token",
+    "generate_salt",
+    "get_current_user",
+    "get_password_hash",
+    "hash_password",
+    "verify_password",
+]

--- a/server/auth/service.py
+++ b/server/auth/service.py
@@ -34,7 +34,11 @@ from .schemas import UserCreate
 
 _pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
 
-_PASSWORD_RE = re.compile(r'^(?=.*[A-Z])(?=.*[a-z])(?=.*\d).{12,}$')
+# Enforce the same policy everywhere: 14+ chars, upper, lower, digit, special.
+# Must stay in sync with crud.validate_password_strength.
+_PASSWORD_RE = re.compile(
+    r'^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()\-_=+,.?":{}|<>]).{14,}$'
+)
 
 
 # ── Password hashing ──────────────────────────────────────────────────────────

--- a/server/config.py
+++ b/server/config.py
@@ -12,10 +12,18 @@ class Settings:
     PERMISSIONS_OTP_LIST: list[str] = [x.strip() for x in _otp_list.split(",") if x.strip()]
 
     # JWT Settings
-    JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY", "fallback_secret_key_for_development_only")
-    # ALGORITHM is intentionally NOT configurable via env to prevent algorithm confusion attacks
-    # (CVE-2024-33664 / CVE-2024-33663 class of vulnerabilities).
-    ALGORITHM: str = "HS256"
+    # JWT_SECRET_KEY must be set explicitly in every environment.
+    # No fallback is provided — if the variable is absent the server refuses
+    # to start, which prevents accidental use of a known/weak key.
+    # Generate a secure value with:
+    #   python -c "import secrets; print(secrets.token_hex(32))"
+    _jwt_raw: Optional[str] = os.getenv("JWT_SECRET_KEY")
+    if not _jwt_raw:
+        raise RuntimeError(
+            "JWT_SECRET_KEY environment variable is required and must not be empty. "
+            "Generate one with: python -c \"import secrets; print(secrets.token_hex(32))\""
+        )
+    JWT_SECRET_KEY: str = _jwt_raw
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "15"))
     REFRESH_TOKEN_EXPIRE_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "7"))
 

--- a/server/main.py
+++ b/server/main.py
@@ -24,7 +24,7 @@ from webauthn.helpers import (
 )
 import random
 import asyncio
-from fastapi import Depends, FastAPI, Header, HTTPException, Request, status
+from fastapi import BackgroundTasks, Depends, FastAPI, Header, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import OAuth2PasswordRequestForm
 from slowapi import Limiter, _rate_limit_exceeded_handler
@@ -43,6 +43,9 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("zero_vault")
 
 # Favicon Engine
+_DNS_TIMEOUT_SECONDS = 2  # hard cap on DNS resolution time
+
+
 def get_favicon_url(site_url: str) -> Optional[str]:
     if not site_url:
         return None
@@ -54,34 +57,40 @@ def get_favicon_url(site_url: str) -> Optional[str]:
         domain = parsed.netloc.lower()
         if not domain:
             domain = parsed.path.split('/')[0].lower()
-        
+
         # Remove 'www.'
         if domain.startswith('www.'):
             domain = domain[4:]
-            
+
         if not domain or '.' not in domain:
             return None
 
-        # SSRF Protection: Check that domain does not resolve to private/internal IP
+        # SSRF Protection: Check that domain does not resolve to private/internal IP.
+        # A 2-second timeout prevents DNS-based timing DoS where a slow resolver
+        # would block the worker indefinitely.
         import socket
         import ipaddress
         try:
-            # DNS lookup with basic SSRF protection
-            ip = socket.gethostbyname(domain)
+            old_timeout = socket.getdefaulttimeout()
+            socket.setdefaulttimeout(_DNS_TIMEOUT_SECONDS)
+            try:
+                ip = socket.gethostbyname(domain)
+            finally:
+                socket.setdefaulttimeout(old_timeout)
+
             ip_obj = ipaddress.ip_address(ip)
-            
-            # Explicitly block RFC1918 and other private ranges
-            if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local or ip_obj.is_multicast:
+
+            # Block RFC1918, loopback, link-local, and multicast ranges
+            if (ip_obj.is_private or ip_obj.is_loopback
+                    or ip_obj.is_link_local or ip_obj.is_multicast):
                 logger.warning(f"SSRF blocked: {domain} resolved to private/reserved IP {ip}")
                 return None
         except Exception as e:
             logger.error(f"DNS lookup failed for {domain}: {e}")
             return None
-            
-        # Priority 1: Clearbit (High Quality)
-        # Priority 2: Google (Fallback)
+
         return f"https://logo.clearbit.com/{domain}?size=128"
-    except:
+    except Exception:
         return None
 
 def validate_base64(data: str) -> bool:
@@ -97,16 +106,11 @@ def validate_base64(data: str) -> bool:
 # Initialize database
 models.Base.metadata.create_all(bind=engine)
 
-# Startup Security Check
-if settings.JWT_SECRET_KEY == "fallback_secret_key_for_development_only":
-    if settings.ENVIRONMENT == "production":
-        logger.critical("SECURITY BREACH: JWT_SECRET_KEY must be configured in production! Shutting down.")
-        raise RuntimeError("JWT_SECRET_KEY check failed")
-    else:
-        logger.warning("Using development fallback for JWT_SECRET_KEY. DO NOT USE IN PRODUCTION.")
+# JWT_SECRET_KEY is validated inside Settings.__init__ — server will not start
+# if the variable is absent, so no redundant check is needed here.
 
-if not settings.TELEGRAM_BOT_TOKEN and settings.ENVIRONMENT == "production":
-    logger.warning("Production mode lacks TELEGRAM_BOT_TOKEN. Security alerts will not be sent.")
+if not settings.TELEGRAM_BOT_TOKEN:
+    logger.warning("TELEGRAM_BOT_TOKEN not set. Security alerts via Telegram will be disabled.")
 
 # Setup Rate Limiter
 limiter = Limiter(key_func=get_remote_address)
@@ -226,11 +230,11 @@ def verify_hardened_otp(db: Session, user: models.User, otp: Optional[str], back
           response_model=schemas.UserResponse,
           status_code=status.HTTP_201_CREATED)
 @limiter.limit("3/minute")
-def register(request: Request,
-             user: schemas.UserCreate,
-             background_tasks: BackgroundTasks,
-             db: Session = Depends(get_db)):
-    # Timing Attack Mitigation
+async def register(request: Request,
+                   user: schemas.UserCreate,
+                   background_tasks: BackgroundTasks,
+                   db: Session = Depends(get_db)):
+    # Timing Attack Mitigation (non-blocking)
     await asyncio.sleep(random.uniform(0.1, 0.3))
     
     # User Enumeration & Policy Protection: Generic responses
@@ -283,10 +287,10 @@ async def login(request: Request,
     )
 
     user = db.query(models.User).filter(models.User.login == form_data.username).with_for_update().first()
-    
+
     if not user:
-        # Constant time-ish delay to prevent timing based enumeration
-        time.sleep(1)
+        # Non-blocking delay to prevent user-enumeration timing attacks
+        await asyncio.sleep(random.uniform(0.1, 0.3))
         crud.audit_event(db, None, "login_failed", {"login": form_data.username, "reason": "user_not_found"}, ip=request.client.host, background_tasks=background_tasks)
         raise common_error
 
@@ -310,7 +314,7 @@ async def login(request: Request,
             crud.audit_event(db, user.id, "account_locked", {"reason": "too_many_login_failures"}, background_tasks=background_tasks)
         
         db.commit()
-        time.sleep(1)
+        await asyncio.sleep(random.uniform(0.1, 0.3))
         crud.audit_event(db, user.id, "login_failed", {"reason": "invalid_password"}, ip=request.client.host, background_tasks=background_tasks)
         raise common_error
 
@@ -358,39 +362,41 @@ def setup_2fa(current_user: models.User = Depends(auth.get_current_user),
 
 @app.post("/2fa/confirm")
 @limiter.limit("5/minute")
-def confirm_2fa(request: Request, 
-                request_data: schemas.TOTPConfirmRequest,
-                background_tasks: BackgroundTasks,
-                db: Session = Depends(get_db)):
-    # If we have user_id in request, use it (for registration flow)
-    # Otherwise try to get from current_user (for logged in users)
-    user_id = request_data.user_id
-    user = None
-    if user_id:
-        user = db.query(models.User).get(user_id)
-    
-    if not user:
-        # Fallback to current authenticated user
-        try:
-            user = auth.get_current_user(request.headers.get("Authorization", "").replace("Bearer ", ""), db)
-        except:
-             raise HTTPException(status_code=401, detail="Authentication required")
-
-    if not user or not user.totp_secret:
+async def confirm_2fa(
+    request: Request,
+    request_data: schemas.TOTPConfirmRequest,
+    background_tasks: BackgroundTasks,
+    # IDOR fix: require JWT auth — endpoint always acts on the authenticated
+    # user, making it impossible to enable 2FA for an arbitrary user_id.
+    current_user: models.User = Depends(auth.get_current_user),
+    db: Session = Depends(get_db),
+):
+    if current_user.totp_enabled:
+        raise HTTPException(status_code=400, detail="2FA already enabled")
+    if not current_user.totp_secret:
         raise HTTPException(status_code=400, detail="2FA not set up")
 
-    totp = pyotp.TOTP(user.totp_secret)
-    if not totp.verify(request_data.code):
-        crud.audit_event(db, user.id, "2fa_confirm_failed", {"reason": "invalid_otp"}, ip=request.client.host, background_tasks=background_tasks)
+    totp = pyotp.TOTP(current_user.totp_secret)
+
+    # Replay-protection: reject a code from a window that was already used
+    current_timecode = int(totp.timecode(datetime.now(timezone.utc)))
+    if current_timecode <= current_user.last_otp_ts:
+        await asyncio.sleep(1)
+        raise HTTPException(status_code=400, detail="OTP already used")
+
+    if not totp.verify(request_data.code, valid_window=1):
+        await asyncio.sleep(1)
+        crud.audit_event(db, current_user.id, "2fa_confirm_failed",
+                         {"reason": "invalid_otp"}, ip=request.client.host,
+                         background_tasks=background_tasks)
         raise HTTPException(status_code=400, detail="Invalid OTP")
 
-    # Set initial timecode to prevent immediate reuse of setup code
-    user.last_otp_ts = int(totp.timecode(datetime.now(timezone.utc)))
-    user.totp_enabled = True
+    current_user.last_otp_ts = current_timecode
+    current_user.totp_enabled = True
     db.commit()
 
-    crud.audit_event(db, user.id, "2fa_enabled", ip=request.client.host, background_tasks=background_tasks)
-
+    crud.audit_event(db, current_user.id, "2fa_enabled",
+                     ip=request.client.host, background_tasks=background_tasks)
     return {"status": "2fa enabled"}
 
 
@@ -433,25 +439,30 @@ def update_profile(request: Request,
 
 @app.post("/refresh")
 @limiter.limit("5/minute")
-def refresh_token(request: Request, payload: dict, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
-    token = payload.get("refresh_token")
-    if not token:
-        crud.audit_event(db, None, "refresh_token_failed", {"reason": "token_missing"}, ip=request.client.host, background_tasks=background_tasks)
-        raise HTTPException(status_code=400, detail="Refresh token missing")
-
+def refresh_token(
+    request: Request,
+    payload: schemas.RefreshRequest,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
     try:
-        data = auth.jwt.decode(token, auth.SECRET_KEY,
-                              algorithms=[auth.ALGORITHM])
-        if data.get("type") != "refresh":
-            crud.audit_event(db, data.get("sub"), "refresh_token_failed", {"reason": "invalid_token_type"}, ip=request.client.host, background_tasks=background_tasks)
-            raise HTTPException(status_code=401, detail="Invalid token type")
-        user_id = data.get("sub")
+        # decode_token uses PyJWT with algorithms=["HS256"] — no algorithm confusion
+        data = auth.decode_token(payload.refresh_token)
     except Exception:
-        crud.audit_event(db, None, "refresh_token_failed", {"reason": "invalid_token"}, ip=request.client.host, background_tasks=background_tasks)
+        crud.audit_event(db, None, "refresh_token_failed", {"reason": "invalid_token"},
+                         ip=request.client.host, background_tasks=background_tasks)
         raise HTTPException(status_code=401, detail="Invalid refresh token")
 
+    if data.get("type") != "refresh":
+        crud.audit_event(db, data.get("sub"), "refresh_token_failed",
+                         {"reason": "invalid_token_type"},
+                         ip=request.client.host, background_tasks=background_tasks)
+        raise HTTPException(status_code=401, detail="Invalid token type")
+
+    user_id = data.get("sub")
     new_access_token = auth.create_access_token(data={"sub": user_id})
-    crud.audit_event(db, user_id, "token_refreshed", ip=request.client.host, background_tasks=background_tasks)
+    crud.audit_event(db, user_id, "token_refreshed", ip=request.client.host,
+                     background_tasks=background_tasks)
     return {"access_token": new_access_token, "token_type": "bearer"}
 
 
@@ -692,8 +703,9 @@ async def webauthn_register_options(
 async def webauthn_register_verify(
     request: Request,
     verify_data: schemas.WebAuthnRegistrationVerify,
+    background_tasks: BackgroundTasks,
     current_user: models.User = Depends(auth.get_current_user),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
     challenge_data = crud.get_challenge(db, verify_data.registration_response.get("challenge"))
     if not challenge_data or challenge_data.type != "registration":
@@ -762,7 +774,8 @@ async def webauthn_login_options(
 async def webauthn_login_verify(
     request: Request,
     verify_data: schemas.WebAuthnLoginVerify,
-    db: Session = Depends(get_db)
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
 ):
     common_error = HTTPException(status_code=400, detail="Authentication failed")
 
@@ -778,8 +791,8 @@ async def webauthn_login_verify(
     db_credential = crud.get_webauthn_credential_by_id(db, credential_id)
     
     if not db_credential:
-        # Prevent credential enumeration
-        time.sleep(1)
+        # Non-blocking delay to prevent credential-enumeration timing attacks
+        await asyncio.sleep(random.uniform(0.1, 0.3))
         raise common_error
 
     user = db.query(models.User).filter(models.User.id == db_credential.user_id).first()


### PR DESCRIPTION
## P0 — Critical

### Remove JWT_SECRET_KEY hardcoded fallback (CWE-798, CVSS 9.1)
- config.py: JWT_SECRET_KEY now REQUIRED; server raises RuntimeError at startup if the env var is absent or empty — no fallback value exists. Eliminates the attack path where ENVIRONMENT != "production" caused the known fallback key to be used silently.
- Removed the redundant post-startup check from main.py that was bypassable via ENVIRONMENT variable tampering.

## P1 — High

### Blocking event-loop (time.sleep in async context) — CWE-400, CVSS 7.0
- main.py: replaced every time.sleep(1) inside async def functions with await asyncio.sleep(random.uniform(0.1, 0.3)). Affected paths: login (user-not-found branch), login (wrong-password branch), webauthn_login_verify (credential-not-found branch). Prevents a trivial DoS where N parallel requests each hold a worker for 1 second (100 req = ~100 s of worker starvation).

### DNS timing DoS in get_favicon_url — CWE-400
- main.py: added a hard 2-second socket timeout around gethostbyname(). Previous code had no timeout; a slow or non-responsive DNS server would block a worker indefinitely. Timeout is saved/restored to avoid side-effects on other socket calls.

## IDOR — duplicate fix in main.py /2fa/confirm
- main.py: /2fa/confirm now requires JWT authentication via Depends(auth.get_current_user) — same fix that was applied to auth/router.py. Removed the unsafe code path that accepted an arbitrary user_id from the request body (unauthenticated callers could enable 2FA on any account).
- Added TOTP replay-protection check (timecode <= last_otp_ts) before code verification, consistent with auth/router.py.

## Broken /refresh endpoint
- main.py: replaced non-existent auth.jwt.decode(token, auth.SECRET_KEY, ...) call with auth.decode_token() from auth/service.py (uses PyJWT with hardcoded algorithms=["HS256"]).
- /refresh now accepts a typed Pydantic schema (RefreshRequest) instead of a bare dict, restoring input validation.

## auth/__init__.py — was empty (NameErrors at startup)
- Re-exported verify_password, hash_password, get_password_hash (alias), create_access_token, create_refresh_token, decode_token, generate_salt, get_current_user so that main.py's auth.X call sites resolve correctly.

## Missing BackgroundTasks import
- Added BackgroundTasks to main.py FastAPI imports.
- Added background_tasks parameter to webauthn_register_verify and webauthn_login_verify endpoints where crud.audit_event was called with background_tasks=background_tasks but the param was not in scope.

## register() sync/async mismatch
- main.py: def register → async def register (was using await inside a sync function, causing RuntimeError at the first call).

## P2 — Medium

### Information disclosure in decrypt_data error (CWE-209)
- auth/service.py: decrypt() already returns a generic "Decryption failed" message via AppException; internal exception string is never forwarded. No code change needed — confirmed correct.

## P3 — Low

### Password regex policy mismatch (auth/service.py vs crud.py)
- auth/service.py: _PASSWORD_RE updated from .{12,} (12 chars, no special char requirement) to match the policy enforced by crud.validate_password_ strength: 14+ chars + uppercase + lowercase + digit + special character. Closes the gap where auth/router.py registration path accepted weaker passwords than main.py registration path.

https://claude.ai/code/session_01W1NvDz3bXCMib8sexGYbam