### PR TITLE
security: JWT revocation (jti+blacklist), logout endpoint, WebAuthn p…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,22 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Security headers as meta equivalents.
+         'wasm-unsafe-eval' is required by Flutter web (Dart → WebAssembly).
+         Adjust connect-src when pointing at a remote API host. -->
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'self';
+                   script-src 'self' 'wasm-unsafe-eval';
+                   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+                   font-src 'self' https://fonts.gstatic.com;
+                   img-src 'self' https://logo.clearbit.com data: assets/;
+                   connect-src 'self';
+                   frame-ancestors 'none';
+                   base-uri 'self';
+                   form-action 'self';">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="X-Frame-Options" content="DENY">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
     <title>Zero Password Manager | Absolute Privacy • Self-Hosted • No Cloud</title>
     <meta name="description"
         content="🔐 Zero Password Manager: The premium, privacy-first, self-hosted vault. AES-256-GCM encryption, Cyberpunk UI, and 100% data ownership. No cloud, no tracking.">

--- a/server/auth/dependencies.py
+++ b/server/auth/dependencies.py
@@ -17,8 +17,20 @@ def get_current_user(
     token: str = Depends(_oauth2_scheme),
     db: Session = Depends(get_db),
 ) -> User:
-    """Resolve a Bearer JWT to a User row. Raises 401 on any failure."""
+    """Resolve a Bearer JWT to a User row. Raises 401 on any failure.
+
+    Checks the token blacklist so explicitly revoked tokens (e.g. after
+    /logout) are rejected even before their exp timestamp elapses.
+    """
+    from .. import crud  # local import — avoids circular module dependency
+
     payload = decode_token(token)
+
+    # Reject blacklisted tokens first — before any user DB lookup so that a
+    # stolen token cannot be used after the legitimate owner logs out.
+    jti = payload.get("jti")
+    if jti and crud.is_token_blacklisted(db, jti):
+        raise InvalidCredentials()
 
     user_id = payload.get("sub")
     if not user_id:

--- a/server/auth/service.py
+++ b/server/auth/service.py
@@ -1,6 +1,7 @@
 import base64
 import re
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -60,6 +61,7 @@ def is_password_strong(password: str) -> bool:
 def create_access_token(data: dict) -> str:
     payload = {
         **data,
+        "jti": str(uuid.uuid4()),  # unique ID — enables per-token revocation
         "exp": datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES),
         "type": "access",
     }
@@ -69,6 +71,7 @@ def create_access_token(data: dict) -> str:
 def create_refresh_token(user_id: int) -> str:
     payload = {
         "sub": str(user_id),
+        "jti": str(uuid.uuid4()),  # unique ID — enables per-token revocation
         "exp": datetime.now(timezone.utc) + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS),
         "type": "refresh",
     }

--- a/server/crud.py
+++ b/server/crud.py
@@ -394,3 +394,37 @@ def get_history(db: Session, user_id: int, background_tasks: BackgroundTasks = N
 
 def get_logs(db: Session, user_id: int):
     return db.query(models.Audit).filter(models.Audit.user_id == user_id).order_by(models.Audit.created_at.desc()).limit(100).all()
+
+
+# ── JWT Revocation / Token Blacklist ──────────────────────────────────────────
+
+def blacklist_token(db: Session, jti: str, expires_at) -> None:
+    """Add a token's jti to the blacklist so it can no longer be used.
+
+    Performs lazy cleanup of expired rows on each call to prevent unbounded
+    growth — no separate cron job required.
+    """
+    from datetime import datetime, timezone
+
+    # Prune expired entries first (lazy GC)
+    db.query(models.TokenBlacklist).filter(
+        models.TokenBlacklist.expires_at < datetime.now(timezone.utc)
+    ).delete(synchronize_session=False)
+
+    # Only insert if not already present (idempotent)
+    existing = db.query(models.TokenBlacklist).filter(
+        models.TokenBlacklist.jti == jti
+    ).first()
+    if not existing:
+        db.add(models.TokenBlacklist(jti=jti, expires_at=expires_at))
+
+    db.commit()
+
+
+def is_token_blacklisted(db: Session, jti: str) -> bool:
+    """Return True if the given jti has been revoked."""
+    return (
+        db.query(models.TokenBlacklist)
+        .filter(models.TokenBlacklist.jti == jti)
+        .first()
+    ) is not None

--- a/server/main.py
+++ b/server/main.py
@@ -1,8 +1,7 @@
 import base64
+import hmac
 import secrets
 import string
-import time
-import hmac
 from typing import List, Optional
 from datetime import datetime, timedelta, timezone
 
@@ -106,11 +105,26 @@ def validate_base64(data: str) -> bool:
 # Initialize database
 models.Base.metadata.create_all(bind=engine)
 
+# ── Startup security assertions ───────────────────────────────────────────────
 # JWT_SECRET_KEY is validated inside Settings.__init__ — server will not start
-# if the variable is absent, so no redundant check is needed here.
+# if the variable is absent.
 
 if not settings.TELEGRAM_BOT_TOKEN:
     logger.warning("TELEGRAM_BOT_TOKEN not set. Security alerts via Telegram will be disabled.")
+
+# WebAuthn: in production the relying-party origin MUST be HTTPS and MUST NOT
+# be localhost. A misconfigured origin allows a phishing site to accept
+# authenticator responses that were meant for the real server.
+if settings.ENVIRONMENT == "production":
+    if not settings.EXPECTED_ORIGIN.startswith("https://"):
+        raise RuntimeError(
+            f"EXPECTED_ORIGIN must use HTTPS in production (got: {settings.EXPECTED_ORIGIN!r})"
+        )
+    if "localhost" in settings.EXPECTED_ORIGIN or "127.0.0.1" in settings.EXPECTED_ORIGIN:
+        raise RuntimeError(
+            "EXPECTED_ORIGIN must not point to localhost in production. "
+            f"Got: {settings.EXPECTED_ORIGIN!r}"
+        )
 
 # Setup Rate Limiter
 limiter = Limiter(key_func=get_remote_address)
@@ -870,6 +884,43 @@ async def revoke_device_endpoint(
     crud.revoke_device(db, device_id, current_user.id)
     crud.audit_event(db, current_user.id, "device_revoked", {"internal_device_id": device_id}, background_tasks=background_tasks)
     return {"status": "success"}
+
+
+@app.post("/logout")
+@limiter.limit("10/minute")
+async def logout(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    current_user: models.User = Depends(auth.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Revoke the current access token by adding its jti to the blacklist.
+
+    After this call the token is rejected by get_current_user even if it has
+    not yet expired.  The client should also discard its refresh token.
+    """
+    token = request.headers.get("Authorization", "").replace("Bearer ", "")
+    try:
+        payload = auth.decode_token(token)
+        jti = payload.get("jti")
+        if jti:
+            exp_ts = payload.get("exp")
+            expires_at = (
+                datetime.fromtimestamp(exp_ts, tz=timezone.utc)
+                if exp_ts
+                else datetime.now(timezone.utc)
+            )
+            crud.blacklist_token(db, jti, expires_at)
+    except Exception:
+        # Token was already invalid; still return 200 so the client can clean up
+        pass
+
+    crud.audit_event(
+        db, current_user.id, "logout",
+        ip=request.client.host,
+        background_tasks=background_tasks,
+    )
+    return {"status": "logged out"}
 
 
 @app.get("/health")

--- a/server/models.py
+++ b/server/models.py
@@ -114,6 +114,21 @@ class PasswordHistory(Base):
     user = relationship("User", back_populates="history")
 
 
+class TokenBlacklist(Base):
+    """JWT revocation store.
+
+    When a user calls /logout the token's ``jti`` claim is written here.
+    get_current_user checks this table so revoked tokens are rejected even
+    before their ``exp`` timestamp.  Rows are pruned lazily on each insert.
+    """
+    __tablename__ = "token_blacklist"
+
+    id = Column(Integer, primary_key=True, index=True)
+    jti = Column(String(36), unique=True, index=True, nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+
 class Audit(Base):
     __tablename__ = "audit"
 


### PR DESCRIPTION
…rod validation, CSP

## JWT Token Revocation — closes the "stolen token" gap

### Why
Previously, when a user logged out the client simply discarded the token locally.  The token remained valid on the server until expiry, so a stolen access token could be used for the full 15-minute window.

### What
- **models.py**: new `TokenBlacklist` table — stores `jti` (UUID per token) and `expires_at` for lazy GC.  Indexed on `jti` for O(log n) lookups.
- **auth/service.py**: `create_access_token` and `create_refresh_token` now embed a `"jti": str(uuid.uuid4())` claim, giving every token a unique revocable identity.
- **crud.py**: `blacklist_token(db, jti, expires_at)` — inserts a row and prunes expired entries on each call (lazy garbage collection, no cron needed).  `is_token_blacklisted(db, jti)` — O(index) lookup.
- **auth/dependencies.py**: `get_current_user` checks the blacklist after verifying the JWT signature.  A revoked token is rejected with 401 before any user DB lookup.
- **main.py**: `POST /logout` — decodes the Bearer token, blacklists its `jti`, writes an audit event and returns `{"status": "logged out"}`. Returns 200 even if the token was already invalid so the client can always clean up safely.

## WebAuthn EXPECTED_ORIGIN startup validation

- **main.py**: on startup in `ENVIRONMENT=production`, asserts that `EXPECTED_ORIGIN` starts with `https://` and does not contain `localhost` or `127.0.0.1`.  Server refuses to start if misconfigured, preventing the phishing-via-fake-origin attack described in the audit.

## CSP for web build (index.html)

- Added `Content-Security-Policy` meta tag with policy that covers the Flutter WebAssembly runtime (`'wasm-unsafe-eval'`), Google Fonts, and Clearbit logo CDN.  `frame-ancestors 'none'` duplicates X-Frame-Options for modern browsers.
- Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` as meta http-equiv fallbacks.
- Added `Referrer-Policy: strict-origin-when-cross-origin` meta tag.

## Cleanup

- **main.py**: removed unused `import time` (all time.sleep calls were replaced with asyncio.sleep in the previous commit).

https://claude.ai/code/session_01W1NvDz3bXCMib8sexGYbam