### PR TITLE
fix: biometric + passkey e2e — login form-data, master key persistenc…

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,16 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'dart:io' show Platform;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../theme/colors.dart';
 import '../config/app_config.dart';
 import '../widgets/otp_input_dialog.dart';
 import '../utils/passkey_service.dart';
+import '../utils/biometric_service.dart';
 import 'package:device_info_plus/device_info_plus.dart';
-import 'screens/folders_screen.dart';
 import '../services/crypto_service.dart';
 import '../services/vault_service.dart';
-import '../services/cache_service.dart';
+import 'package:cryptography/cryptography.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -25,6 +26,8 @@ class _LoginScreenState extends State<LoginScreen> {
   bool _isLoading = false;
   String? _errorMessage;
   final PasskeyService _passkeyService = PasskeyService();
+
+  // ── Password login ─────────────────────────────────────────────────────────
 
   Future<void> _login() async {
     setState(() {
@@ -44,25 +47,25 @@ class _LoginScreenState extends State<LoginScreen> {
     }
 
     try {
+      // Server uses OAuth2PasswordRequestForm — must send x-www-form-urlencoded
+      // with field names "username" and "password".
       final response = await http.post(
         Uri.parse(AppConfig.loginUrl),
-        headers: {'Content-Type': 'application/json'},
-        body: json.encode({'login': login, 'password': password}),
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: 'username=${Uri.encodeComponent(login)}'
+            '&password=${Uri.encodeComponent(password)}',
       );
 
       final data = json.decode(response.body);
 
       if (response.statusCode == 200) {
         if (data['two_fa_required'] == true) {
-          // Показываем ввод OTP
           if (!mounted) return;
           final String? otpCode = await showDialog<String>(
             context: context,
             builder: (context) => const OTPInputDialog(),
           );
-
           if (otpCode != null) {
-            // Повторяем логин с OTP в заголовке
             await _loginWithOTP(login, password, otpCode);
           } else {
             setState(() => _isLoading = false);
@@ -70,37 +73,88 @@ class _LoginScreenState extends State<LoginScreen> {
           return;
         }
 
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setString('token', data['access_token']); // Backend returns access_token
-        
-        // Zero-Knowledge: Derive and set Master Key
-        final salt = data['salt'];
-        if (salt != null) {
-          await VaultService().unlock(password, salt);
-        }
-
-        // Проверяем, установлен ли PIN-код
-        final pinCode = prefs.getString('pin_code');
-        if (pinCode != null) {
-          Navigator.pushReplacementNamed(context, '/pin');
-        } else {
-          Navigator.pushReplacementNamed(context, '/setup-pin');
-        }
+        await _onLoginSuccess(data, password);
       } else {
         setState(() {
-          _errorMessage = data['error'] ?? 'Ошибка авторизации';
+          _errorMessage = data['detail'] ?? data['error'] ?? 'Ошибка авторизации';
+          _isLoading = false;
         });
       }
     } catch (e) {
       setState(() {
         _errorMessage = 'Ошибка подключения к серверу';
-      });
-    } finally {
-      setState(() {
         _isLoading = false;
       });
     }
   }
+
+  Future<void> _loginWithOTP(String login, String password, String otp) async {
+    setState(() => _isLoading = true);
+    try {
+      final response = await http.post(
+        Uri.parse(AppConfig.loginUrl),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-OTP': otp,
+        },
+        body: 'username=${Uri.encodeComponent(login)}'
+            '&password=${Uri.encodeComponent(password)}',
+      );
+
+      final data = json.decode(response.body);
+
+      if (response.statusCode == 200) {
+        await _onLoginSuccess(data, password);
+      } else {
+        setState(() {
+          _errorMessage = data['detail'] ?? 'Неверный код OTP';
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'Ошибка подключения';
+        _isLoading = false;
+      });
+    }
+  }
+
+  /// Common post-login setup: store token, derive master key, store it for
+  /// biometric unlock, navigate to PIN.
+  Future<void> _onLoginSuccess(Map<String, dynamic> data, String password) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('token', data['access_token'] ?? '');
+
+    final salt = data['salt'] as String?;
+    if (salt != null && password.isNotEmpty) {
+      // Derive and unlock the vault
+      await VaultService().unlock(password, salt);
+
+      // Persist master key for biometric unlock so the vault can be opened
+      // without re-entering the master password.
+      final masterKey = VaultService().masterKey;
+      if (masterKey != null) {
+        final keyBytes = await masterKey.extractBytes();
+        final keyB64 = base64.encode(keyBytes);
+        // Store in secure storage (used by passkey and biometric flows)
+        await _passkeyService.saveVaultKey(keyB64);
+        // Also store in flutter_locker if biometrics are enabled
+        if (await BiometricService.isBiometricEnabled()) {
+          await BiometricService.storeBiometricSecret(keyB64);
+        }
+      }
+    }
+
+    if (!mounted) return;
+    final pinHash = prefs.getString('pin_hash');
+    if (pinHash != null) {
+      Navigator.pushReplacementNamed(context, '/pin');
+    } else {
+      Navigator.pushReplacementNamed(context, '/setup-pin');
+    }
+  }
+
+  // ── Passkey login ──────────────────────────────────────────────────────────
 
   Future<void> _loginWithPasskey() async {
     setState(() {
@@ -124,80 +178,38 @@ class _LoginScreenState extends State<LoginScreen> {
 
       if (data != null && data['access_token'] != null) {
         final prefs = await SharedPreferences.getInstance();
-        await prefs.setString('token', data['access_token']);
-        
-        final vaultKey = await _passkeyService.getVaultKey();
-        if (vaultKey == null) {
-           if (mounted) {
-             ScaffoldMessenger.of(context).showSnackBar(
-               const SnackBar(content: Text('Вход выполнен. Требуется синхронизация ключа хранилища.')),
-             );
-           }
+        await prefs.setString('token', data['access_token'] as String);
+
+        // Restore master key from secure storage (saved during password login)
+        final vaultKeyB64 = await _passkeyService.getVaultKey();
+        if (vaultKeyB64 != null) {
+          VaultService().setKey(SecretKey(base64.decode(vaultKeyB64)));
+        } else {
+          // Key not available — user must log in with password once to seed it
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text(
+                  'Войдите один раз с паролем, чтобы активировать быстрый вход.',
+                ),
+                backgroundColor: Colors.orange,
+              ),
+            );
+          }
         }
 
         if (!mounted) return;
-        final pinCode = prefs.getString('pin_code');
-        if (pinCode != null) {
+        final pinHash = prefs.getString('pin_hash');
+        if (pinHash != null) {
           Navigator.pushReplacementNamed(context, '/pin');
         } else {
           Navigator.pushReplacementNamed(context, '/setup-pin');
         }
       } else {
-        setState(() {
-          _errorMessage = 'Ошибка входа через Passkey';
-        });
+        setState(() => _errorMessage = 'Ошибка входа через Passkey');
       }
     } catch (e) {
-      setState(() {
-        _errorMessage = 'Ошибка: $e';
-      });
-    } finally {
-      setState(() {
-        _isLoading = false;
-      });
-    }
-  }
-
-  Future<void> _loginWithOTP(String login, String password, String otp) async {
-    setState(() => _isLoading = true);
-    try {
-      final response = await http.post(
-        Uri.parse(AppConfig.loginUrl),
-        headers: {
-          'Content-Type': 'application/json',
-          'X-OTP': otp,
-        },
-        body: json.encode({'login': login, 'password': password}),
-      );
-
-      final data = json.decode(response.body);
-
-      if (response.statusCode == 200) {
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setString('token', data['access_token']);
-        
-        // Zero-Knowledge: Derive and set Master Key
-        final salt = data['salt'];
-        if (salt != null) {
-          await VaultService().unlock(password, salt);
-        }
-
-        if (!mounted) return;
-        final pinCode = prefs.getString('pin_code');
-        if (pinCode != null) {
-          Navigator.pushReplacementNamed(context, '/pin');
-        } else {
-          Navigator.pushReplacementNamed(context, '/setup-pin');
-        }
-      } else {
-        setState(() {
-          _errorMessage = data['detail'] ?? 'Неверный код OTP';
-        });
-      }
-    } catch (e) {
-      setState(() {
-        _errorMessage = 'Ошибка подключения';
-      });
+      setState(() => _errorMessage = 'Ошибка: $e');
     } finally {
       setState(() => _isLoading = false);
     }
@@ -214,11 +226,12 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Center(
-        child: Padding(
+        child: SingleChildScrollView(
           padding: const EdgeInsets.all(24.0),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
+              // Logo
               Container(
                 margin: const EdgeInsets.only(bottom: 60),
                 child: Column(
@@ -282,58 +295,91 @@ class _LoginScreenState extends State<LoginScreen> {
                   ],
                 ),
               ),
-              
+
+              // Login field
               TextField(
                 controller: _loginController,
+                autocorrect: false,
                 decoration: InputDecoration(
                   hintText: 'Логин',
                   filled: true,
                   fillColor: AppColors.input,
-                  border: OutlineInputBorder(),
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.person),
                 ),
               ),
               const SizedBox(height: 16),
+
+              // Password field
               TextField(
                 controller: _passwordController,
                 obscureText: true,
+                autocorrect: false,
                 decoration: InputDecoration(
                   hintText: 'Пароль',
                   filled: true,
                   fillColor: AppColors.input,
-                  border: OutlineInputBorder(),
+                  border: const OutlineInputBorder(),
+                  prefixIcon: const Icon(Icons.lock),
                 ),
+                onSubmitted: (_) => _login(),
               ),
               const SizedBox(height: 16),
+
               if (_errorMessage != null)
                 Padding(
                   padding: const EdgeInsets.only(bottom: 12),
-                  child: Text(
-                    _errorMessage!,
-                    style: const TextStyle(color: Colors.red),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: Colors.red.withOpacity(0.1),
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: Colors.red.withOpacity(0.3)),
+                    ),
+                    child: Text(
+                      _errorMessage!,
+                      style: const TextStyle(color: Colors.red),
+                      textAlign: TextAlign.center,
+                    ),
                   ),
                 ),
+
+              // Login button
               _isLoading
                   ? const CircularProgressIndicator()
                   : ElevatedButton(
                       onPressed: _login,
                       style: ElevatedButton.styleFrom(
                         backgroundColor: AppColors.button,
-                        padding: const EdgeInsets.symmetric(horizontal: 60, vertical: 16),
+                        minimumSize: const Size(double.infinity, 50),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
                       ),
-                      child: const Text('Войти'),
+                      child: const Text(
+                        'Войти',
+                        style: TextStyle(fontSize: 16, color: Colors.white),
+                      ),
                     ),
               const SizedBox(height: 16),
+
+              // Passkey button
               OutlinedButton.icon(
                 onPressed: _isLoading ? null : _loginWithPasskey,
                 icon: const Icon(Icons.fingerprint),
-                label: const Text('Войти с Passkey'),
+                label: const Text('Войти с Passkey / биометрией'),
                 style: OutlinedButton.styleFrom(
-                  minimumSize: const Size(200, 50),
+                  minimumSize: const Size(double.infinity, 50),
                   side: BorderSide(color: AppColors.button),
                   foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
                 ),
               ),
               const SizedBox(height: 16),
+
               TextButton(
                 onPressed: () => Navigator.pushNamed(context, '/signup'),
                 child: const Text('Нет аккаунта? Зарегистрироваться'),

--- a/lib/screens/pin_screen.dart
+++ b/lib/screens/pin_screen.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:crypto/crypto.dart';
+import 'dart:convert';
 import 'dart:typed_data';
 import '../theme/colors.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 import '../config/app_config.dart';
 import '../utils/biometric_service.dart';
+import '../services/vault_service.dart';
+import 'package:cryptography/cryptography.dart';
 
 class PinScreen extends StatefulWidget {
   const PinScreen({super.key});
@@ -263,28 +266,40 @@ class _PinScreenState extends State<PinScreen> with TickerProviderStateMixin {
 
   Future<void> _authenticateWithBiometrics() async {
     try {
-      final authenticated = await BiometricService.authenticate(
+      // authenticate() returns the stored secret (base64 master key) on
+      // success, or null on failure/cancellation.
+      final vaultKeyB64 = await BiometricService.authenticate(
         reason: 'Подтвердите свою личность для доступа к паролям',
       );
 
-      if (authenticated) {
-        Navigator.pushNamedAndRemoveUntil(
-          context,
-          '/passwords',
-          (route) => false,
-        );
+      if (vaultKeyB64 != null) {
+        // Restore the in-memory master key so the vault is usable.
+        VaultService().setKey(SecretKey(base64.decode(vaultKeyB64)));
+
+        if (mounted) {
+          Navigator.pushNamedAndRemoveUntil(
+            context,
+            '/passwords',
+            (route) => false,
+          );
+        }
       } else {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
               backgroundColor: Colors.orange,
-              content: Text('Биометрическая аутентификация не удалась. Используйте PIN-код.'),
+              content: Text(
+                  'Биометрическая аутентификация не удалась. Используйте PIN-код.'),
             ),
           );
         }
       }
     } catch (e) {
-      print('PIN Screen - Biometric authentication error: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Ошибка биометрии: $e')),
+        );
+      }
     }
   }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -6,7 +6,8 @@ import '../theme/colors.dart';
 import '../config/app_config.dart';
 import '../utils/biometric_service.dart';
 import '../utils/passkey_service.dart';
-import 'package:nk3_zero/utils/api_service.dart';
+import '../utils/api_service.dart';
+import '../services/vault_service.dart';
 import 'dart:io';
 import 'package:device_info_plus/device_info_plus.dart';
 
@@ -288,23 +289,40 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _toggleBiometric(bool value) async {
     if (value) {
-      // Включаем биометрическую аутентификацию
+      // ── Enable biometrics ──────────────────────────────────────────────────
+      // To protect the vault we must store the master key encrypted by
+      // the biometric credential.  The vault must already be unlocked.
       try {
-        final bool authenticated = await BiometricService.authenticate(
-          reason: 'Подтвердите свою личность для включения биометрической аутентификации',
-        );
-        
-        if (authenticated) {
+        final masterKey = VaultService().masterKey;
+        if (masterKey == null) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                backgroundColor: Colors.orange,
+                content: Text(
+                  'Откройте хранилище (войдите с паролем) перед включением биометрии.',
+                ),
+              ),
+            );
+          }
+          return;
+        }
+
+        final keyBytes = await masterKey.extractBytes();
+        final keyB64 = base64.encode(keyBytes);
+
+        // storeBiometricSecret shows the biometric prompt — returns true on success.
+        final stored = await BiometricService.storeBiometricSecret(keyB64);
+        if (stored) {
           await BiometricService.setBiometricEnabled(true);
-          setState(() {
-            _biometricEnabled = true;
-          });
-          
+          // Also persist in PasskeyService secure storage as fallback
+          await PasskeyService().saveVaultKey(keyB64);
+          setState(() => _biometricEnabled = true);
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 backgroundColor: Colors.green,
-                content: Text('$_biometricType включен'),
+                content: Text('$_biometricType включён'),
               ),
             );
           }
@@ -313,7 +331,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(
                 backgroundColor: Colors.red,
-                content: Text('Аутентификация не пройдена'),
+                content: Text('Не удалось сохранить биометрические данные'),
               ),
             );
           }
@@ -321,9 +339,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
       } catch (e) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
+            SnackBar(
               backgroundColor: Colors.red,
-              content: Text('Ошибка при включении биометрической аутентификации'),
+              content: Text('Ошибка: $e'),
             ),
           );
         }

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -6,6 +6,7 @@ import '../config/app_config.dart';
 import '../widgets/two_factor_setup_dialog.dart';
 import '../services/vault_service.dart';
 import '../services/crypto_service.dart';
+import '../utils/passkey_service.dart';
 
 class SignUpScreen extends StatefulWidget {
   const SignUpScreen({super.key});
@@ -67,13 +68,19 @@ class _SignUpScreenState extends State<SignUpScreen> {
           final salt = data['salt'];
           if (salt != null) {
             await VaultService().unlock(password, salt);
+            // Persist vault key so passkey / biometric login can restore it
+            final masterKey = VaultService().masterKey;
+            if (masterKey != null) {
+              final keyBytes = await masterKey.extractBytes();
+              await PasskeyService().saveVaultKey(base64.encode(keyBytes));
+            }
           }
 
           if (!mounted) return;
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Регистрация и 2FA успешно настроены')),
           );
-          Navigator.pushReplacementNamed(context, '/passwords'); // Direct to vault if unlocked
+          Navigator.pushReplacementNamed(context, '/setup-pin'); // Set up PIN after registration
         }
       } else {
         setState(() {

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -33,10 +33,12 @@ class VaultService {
   /// Derives the master key and unlocks the vault.
   Future<void> unlock(String password, String salt) async {
     _masterKey = await _crypto.deriveMasterKey(password, salt);
-    
-    // If biometrics are enabled, store the master key securely
+
+    // If biometrics are enabled, persist the key so the vault can be
+    // unlocked without the master password on the next app launch.
     if (await BiometricService.isBiometricEnabled()) {
-      await BiometricService.storeBiometricSecret(base64.encode(_masterKey!));
+      final keyBytes = await _masterKey!.extractBytes();
+      await BiometricService.storeBiometricSecret(base64.encode(keyBytes));
     }
   }
 

--- a/lib/utils/passkey_service.dart
+++ b/lib/utils/passkey_service.dart
@@ -8,7 +8,6 @@ import 'api_service.dart';
 class PasskeyService {
   final _passkeyAuth = PasskeyAuthenticator();
   final _storage = const FlutterSecureStorage();
-  final ApiService _apiService = ApiService();
 
   static const String _vaultKeyKey = 'vault_key_encrypted';
 

--- a/server/main.py
+++ b/server/main.py
@@ -102,6 +102,30 @@ def validate_base64(data: str) -> bool:
         return False
 
 
+def _extract_webauthn_challenge(response: dict) -> Optional[str]:
+    """Extract the challenge string from a WebAuthn credential response.
+
+    The passkeys Flutter package does not add a top-level 'challenge' field;
+    the challenge lives inside the base64url-encoded clientDataJSON.
+    We decode it here so we can look it up in the challenges table.
+    """
+    try:
+        import json as _json
+        client_data_b64 = (
+            response.get("response", {}).get("clientDataJSON") or
+            response.get("clientDataJSON")
+        )
+        if not client_data_b64:
+            return None
+        # base64url → bytes (add padding if needed)
+        padded = client_data_b64 + "=" * (-len(client_data_b64) % 4)
+        client_data = _json.loads(base64.urlsafe_b64decode(padded))
+        return client_data.get("challenge")
+    except Exception as exc:
+        logger.warning(f"Could not extract challenge from clientDataJSON: {exc}")
+        return None
+
+
 # Initialize database
 models.Base.metadata.create_all(bind=engine)
 # Apply column migrations for tables that already exist
@@ -731,7 +755,11 @@ async def webauthn_register_verify(
     current_user: models.User = Depends(auth.get_current_user),
     db: Session = Depends(get_db),
 ):
-    challenge_data = crud.get_challenge(db, verify_data.registration_response.get("challenge"))
+    challenge_key = (
+        verify_data.registration_response.get("challenge")
+        or _extract_webauthn_challenge(verify_data.registration_response)
+    )
+    challenge_data = crud.get_challenge(db, challenge_key)
     if not challenge_data or challenge_data.type != "registration":
         raise HTTPException(status_code=400, detail="Invalid challenge")
     
@@ -803,7 +831,11 @@ async def webauthn_login_verify(
 ):
     common_error = HTTPException(status_code=400, detail="Authentication failed")
 
-    challenge_data = crud.get_challenge(db, verify_data.authentication_response.get("challenge"))
+    challenge_key = (
+        verify_data.authentication_response.get("challenge")
+        or _extract_webauthn_challenge(verify_data.authentication_response)
+    )
+    challenge_data = crud.get_challenge(db, challenge_key)
     if not challenge_data or challenge_data.type != "authentication":
         raise common_error
     


### PR DESCRIPTION
…e, WebAuthn challenge extraction

- Fix login to use application/x-www-form-urlencoded (OAuth2PasswordRequestForm)
- Fix PIN hash key name (pin_hash not pin_code)
- Add _onLoginSuccess: derive master key, save to secure storage + BiometricService
- Fix VaultService.masterKey getter and extractBytes() usage (SecretKey is not List<int>)
- Fix BiometricService.authenticate() return type (String? not bool) in pin_screen
- Fix biometric enable flow in settings: store key first, then enable
- Fix passkey login: restore VaultService key from secure storage after success
- Add WebAuthn _extract_webauthn_challenge() — decode challenge from clientDataJSON since Flutter passkeys package doesn't add top-level challenge field
- Apply challenge extraction to both register/verify and login/verify endpoints
- Fix signup: save vault key to PasskeyService after registration

https://claude.ai/code/session_01B5ZkZZDZctjhs6jA1Cjfa3