### PR TITLE
fix: repair broken biometric authentication flow

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -14,6 +14,7 @@ import '../services/vault_service.dart';
 import '../models/server_error.dart';
 import '../utils/form_error_handler.dart';
 import '../utils/security_utils.dart';
+import '../utils/pin_security.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -153,8 +154,8 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
     }
 
     if (!mounted) return;
-    final pinHash = prefs.getString('pin_hash');
-    if (pinHash != null) {
+    final hasPinHash = await PinSecurity.hasPinHash();
+    if (hasPinHash) {
       Navigator.pushReplacementNamed(context, '/pin');
     } else {
       Navigator.pushReplacementNamed(context, '/setup-pin');
@@ -181,8 +182,8 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
         await prefs.setString('token', data['access_token']);
 
         if (!mounted) return;
-        final pinHash = prefs.getString('pin_hash');
-        if (pinHash != null) {
+        final hasPinHash = await PinSecurity.hasPinHash();
+        if (hasPinHash) {
           Navigator.pushReplacementNamed(context, '/pin');
         } else {
           Navigator.pushReplacementNamed(context, '/setup-pin');

--- a/lib/screens/pin_screen.dart
+++ b/lib/screens/pin_screen.dart
@@ -298,11 +298,8 @@ class _PinScreenState extends State<PinScreen> with TickerProviderStateMixin {
 
   Future<void> _authenticateWithBiometrics() async {
     try {
-      final authSecret = await BiometricService.authenticate(
-        reason: 'Подтвердите свою личность для доступа к паролям',
-      );
-      if (authSecret != null) {
-        await VaultService().tryUnlockWithBiometrics();
+      final success = await VaultService().tryUnlockWithBiometrics();
+      if (success) {
         SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
         if (mounted) {
           Navigator.pushNamedAndRemoveUntil(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,10 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'dart:typed_data';
 import '../theme/colors.dart';
 import '../config/app_config.dart';
 import '../utils/biometric_service.dart';
 import '../utils/passkey_service.dart';
+import '../utils/pin_security.dart';
 import 'package:nk3_zero/utils/api_service.dart';
 import 'dart:io';
 import 'package:device_info_plus/device_info_plus.dart';
@@ -61,12 +63,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _checkPinCodeStatus() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final pinHash = prefs.getString('pin_hash');
-      final pinCode = prefs.getString('pin_code');
-
+      final hasPinHash = await PinSecurity.hasPinHash();
       setState(() {
-        _hasPinCode = pinHash != null || pinCode != null;
+        _hasPinCode = hasPinHash;
         _isLoading = false;
       });
     } catch (e) {
@@ -242,6 +241,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
         await prefs.remove('pin_code');
         await prefs.remove('pin_hash');
 
+        // Clear PIN hash and attempt data from FlutterSecureStorage
+        await PinSecurity.clearPinData();
         // Also clear persistent key since PIN is gone
         await VaultService().clearAllData();
 
@@ -498,14 +499,29 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _toggleBiometric(bool value) async {
     if (value) {
-      // Включаем биометрическую аутентификацию
+      // Включаем биометрическую аутентификацию — сохраняем мастер-ключ в биометрическое хранилище
       try {
-        final authSecret = await BiometricService.authenticate(
-          reason:
-              'Подтвердите свою личность для включения биометрической аутентификации',
-        );
+        final vault = VaultService();
+        if (vault.isLocked) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                backgroundColor: Colors.orange,
+                content: Text('Хранилище заблокировано. Войдите через PIN для включения биометрии.'),
+              ),
+            );
+          }
+          return;
+        }
 
-        if (authSecret != null) {
+        final keyBytes = await vault.masterKey!.extractBytes();
+        final keyB64 = base64.encode(keyBytes);
+        // Zero raw bytes immediately after encoding
+        (keyBytes as Uint8List).fillRange(0, keyBytes.length, 0);
+
+        final stored = await BiometricService.storeBiometricSecret(keyB64);
+
+        if (stored) {
           await BiometricService.setBiometricEnabled(true);
           setState(() {
             _biometricEnabled = true;

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -6,6 +6,7 @@ import 'package:nk3_zero/screens/login_screen.dart';
 import 'package:nk3_zero/screens/pin_screen.dart';
 import 'package:nk3_zero/screens/setup_pin_screen.dart';
 import '../config/app_config.dart';
+import '../utils/pin_security.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
@@ -53,7 +54,7 @@ class _SplashScreenState extends State<SplashScreen> {
   Future<void> _navigateNext() async {
     final prefs = await SharedPreferences.getInstance();
     final token = prefs.getString('token');
-    final pinHash = prefs.getString('pin_hash');
+    final hasPinHash = await PinSecurity.hasPinHash();
 
     if (!mounted) return;
 
@@ -66,7 +67,7 @@ class _SplashScreenState extends State<SplashScreen> {
       MaterialPageRoute(
         builder: (context) {
           if (token != null) {
-            if (pinHash != null) {
+            if (hasPinHash) {
               return const PinScreen();
             } else {
               return const SetupPinScreen();


### PR DESCRIPTION
- login_screen: route to /pin using PinSecurity.hasPinHash() instead of stale SharedPreferences pin_hash key (CVE fix moved it to FlutterSecureStorage)
- splash_screen: same fix for app-startup routing
- settings_screen: fix _checkPinCodeStatus to use PinSecurity.hasPinHash(); fix _removePinCode to also call PinSecurity.clearPinData() for full cleanup; fix _toggleBiometric(true) to store master key via storeBiometricSecret() instead of incorrectly calling authenticate() (retrieve) before any secret is stored — vault must be unlocked first, then key is saved to biometric store
- pin_screen: eliminate double biometric prompt by removing redundant BiometricService.authenticate() call before VaultService.tryUnlockWithBiometrics()

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1