### PR TITLE
fix: upgrade safe_device and flutter_locker to fix Android v1 embeddi…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   shared_preferences: ^2.2.0
   file_picker: ^10.2.0
   flutter_dotenv: ^5.1.0
-  flutter_locker: ^2.1.6
+  flutter_locker: ^2.2.0
   qr_flutter: ^4.1.0
   passkeys: ^2.8.2
   flutter_secure_storage: ^9.0.0
@@ -50,11 +50,11 @@ dependencies:
   cupertino_icons: ^1.0.2
   crypto: ^3.0.3
   shimmer: ^3.0.0
-  flutter_native_splash: ^2.4.6
+  flutter_native_splash: ^2.4.7
   device_info_plus: ^10.0.0
   flutter_local_notifications: ^18.0.1
   web_socket_channel: ^3.0.3
-  safe_device: ^1.1.4
+  safe_device: ^1.3.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
…ng error

safe_device 1.1.4 (released Aug 2023) still contained the deprecated PluginRegistry.Registrar (v1 embedding) API. Flutter 3.22+ treats this as a hard build error ("use of deleted Android v1 embedding").

- safe_device: ^1.1.4  →  ^1.3.8  (v2 embedding migration included)
- flutter_locker: ^2.1.6  →  ^2.2.0  (v2 embedding compatibility fix)
- flutter_native_splash: ^2.4.6  →  ^2.4.7  (patch)

flutter_local_notifications stays at ^18.0.1 — v21 requires Flutter ≥3.38.1 which exceeds our current CI target (3.32.0).

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1