### PR TITLE
fix: upgrade AGP to 8.7.0, Kotlin to 2.0.21, add Gradle 8.10.2 wrapper

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,12 +23,12 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.1.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+    id("com.android.application") version "8.7.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 }
 
 include(":app")


### PR DESCRIPTION
Flutter 3.29+ removed Android v1 embedding and requires:
  - Kotlin 2.0.21 (was 1.9.10)
  - AGP 8.7.0 (was 8.1.0)
  - Gradle 8.10.2 (wrapper was missing)
  - Java 17 jvmTarget (aligned with CI JDK 17)

These outdated toolchain versions were preventing successful APK builds with Flutter 3.32.0 and causing the "Build failed due to use of deleted Android v1 embedding" error.

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1