### PR TITLE
fix: NDK 27.0.12077973 and remove stale _masterKey setter

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -20,7 +20,7 @@ val keystoreProperties = Properties().apply {
 android {
     namespace = "com.example.nk3_zero"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -116,7 +116,6 @@ class _SignUpScreenState extends State<SignUpScreen> with SingleTickerProviderSt
       // 1. Client-side Zero-Knowledge: Generate salt and derive Master Key
       final salt = VaultService.generateRandomSalt();
       final masterKey = await VaultService.generateMasterKey(password, salt);
-      setState(() => _masterKey = masterKey);
 
       // 2. Send registration request with the client-generated salt
       final response = await http.post(


### PR DESCRIPTION
Two build errors from actual Flutter output:

1. NDK version mismatch: all plugins require NDK 27.0.12077973 but build.gradle.kts used flutter.ndkVersion (26.3.11579264). Set explicit ndkVersion = "27.0.12077973" per Flutter's recommendation.

2. Dart compile error in signup_screen.dart:119 — setState set _masterKey which was removed as a class field in a previous CVE fix. The local masterKey variable is already passed to VaultService.saveMasterKey() on line 149; the setState was dead code and is now removed.

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1