### PR TITLE
fix: enable core library desugaring for flutter_local_notifications

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -25,6 +25,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -86,4 +87,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }


### PR DESCRIPTION
flutter_local_notifications requires isCoreLibraryDesugaringEnabled = true and the desugar_jdk_libs dependency to use java.time APIs on pre-API-26 Android devices.

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1