### PR TITLE
debug: add detailed WARNING logs to diagnose 401 on confirm_2fa

### DIFF
--- a/server/auth/dependencies.py
+++ b/server/auth/dependencies.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Callable
 
 from fastapi import Depends, HTTPException, Request, status
@@ -11,6 +12,7 @@ from .exceptions import InvalidCredentials
 from .service import decode_token, verify_hardened_otp
 
 _oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+_log = logging.getLogger(__name__)
 
 
 def get_current_user(
@@ -24,23 +26,35 @@ def get_current_user(
     """
     from .. import crud  # local import — avoids circular module dependency
 
-    payload = decode_token(token)
+    try:
+        payload = decode_token(token)
+    except Exception as exc:
+        _log.warning("get_current_user: decode_token failed — %s", exc)
+        raise InvalidCredentials()
 
     # Reject blacklisted tokens first — before any user DB lookup so that a
     # stolen token cannot be used after the legitimate owner logs out.
     jti = payload.get("jti")
     if jti and crud.is_token_blacklisted(db, jti):
+        _log.warning("get_current_user: token jti=%s is blacklisted", jti)
         raise InvalidCredentials()
 
     user_id = payload.get("sub")
     if not user_id:
+        _log.warning("get_current_user: token missing 'sub' claim")
         raise InvalidCredentials()
 
     user = db.query(User).filter(User.id == int(user_id)).first()
     if not user:
+        _log.warning("get_current_user: user id=%s not found in DB", user_id)
         raise InvalidCredentials()
 
-    if payload.get("token_version") != user.token_version:
+    token_ver = payload.get("token_version")
+    if token_ver != user.token_version:
+        _log.warning(
+            "get_current_user: token_version mismatch — token=%r db=%r user_id=%s",
+            token_ver, user.token_version, user_id,
+        )
         raise InvalidCredentials()
 
     return user

--- a/server/auth/router.py
+++ b/server/auth/router.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import secrets
 from datetime import datetime, timedelta
 
@@ -7,6 +8,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
+
+_log = logging.getLogger(__name__)
 
 from ..audit.service import record as audit
 from ..database import get_db
@@ -417,6 +420,10 @@ async def confirm_2fa(
             for offset in (-30, 0, 30)
         )
         if not valid:
+            _log.warning(
+                "confirm_2fa: invalid TOTP code for user_id=%s ip=%s",
+                current_user.id, ip_address,
+            )
             handle_failed_otp_attempt(db, current_user, ip_address)
             log_security_event(db, current_user.id, "2fa_setup_failed",
                 {"ip": ip_address}, ip_address)
@@ -427,6 +434,10 @@ async def confirm_2fa(
     except HTTPException:
         raise
     except Exception as e:
+        _log.exception(
+            "confirm_2fa: unexpected error during TOTP check for user_id=%s: %s",
+            current_user.id, e,
+        )
         handle_failed_otp_attempt(db, current_user, ip_address)
         log_security_event(db, current_user.id, "2fa_setup_failed",
             {"error": str(e), "ip": ip_address}, ip_address)
@@ -435,7 +446,7 @@ async def confirm_2fa(
 
     # Включаем 2FA
     current_user.totp_enabled = True
-    current_user.last_otp_ts = pyotp.TOTP(decrypt_totp(current_user.totp_secret, current_user.id)).timecode(datetime.utcnow())
+    current_user.last_otp_ts = totp_obj.timecode(datetime.utcnow())  # reuse already-decrypted totp_obj
     db.commit()
     
     # Генерация токенов


### PR DESCRIPTION
- get_current_user now logs the specific reason for each 401: decode_token failure, blacklisted token, user not found, or token_version mismatch (with actual values)
- confirm_2fa logs when TOTP code is wrong or an unexpected exception occurs during TOTP decryption/verification
- Fix minor: reuse already-decrypted totp_obj for last_otp_ts instead of calling decrypt_totp a second time

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1