### PR TITLE
fix: accept enrollment token from Authorization header OR mfa_token b…

### DIFF
--- a/lib/widgets/two_factor_setup_dialog.dart
+++ b/lib/widgets/two_factor_setup_dialog.dart
@@ -97,10 +97,17 @@ class _TwoFactorSetupDialogState extends State<TwoFactorSetupDialog> {
       if (widget.enrollmentToken != null) {
         headers['Authorization'] = 'Bearer ${widget.enrollmentToken}';
       }
+      // Also send the enrollment token in the body as mfa_token so the server
+      // can authenticate the request even if the Authorization header is dropped
+      // by a proxy or unavailable in older app builds.
+      final body = <String, dynamic>{'code': code};
+      if (widget.enrollmentToken != null) {
+        body['mfa_token'] = widget.enrollmentToken;
+      }
       final response = await http.post(
         Uri.parse(AppConfig.confirm2faUrl),
         headers: headers,
-        body: json.encode({'code': code}),
+        body: json.encode(body),
       );
 
       if (response.statusCode == 200) {

--- a/server/auth/dependencies.py
+++ b/server/auth/dependencies.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable
+from typing import Callable, Optional
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer
@@ -12,52 +12,62 @@ from .exceptions import InvalidCredentials
 from .service import decode_token, verify_hardened_otp
 
 _oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
+_oauth2_scheme_optional = OAuth2PasswordBearer(tokenUrl="login", auto_error=False)
 _log = logging.getLogger(__name__)
+
+
+def _resolve_user_from_token(token: str, db: Session) -> User:
+    """Decode a Bearer JWT and return the corresponding User. Raises InvalidCredentials on any failure."""
+    from .. import crud  # local import — avoids circular module dependency
+
+    try:
+        payload = decode_token(token)
+    except Exception as exc:
+        _log.warning("resolve_user: decode_token failed — %s", exc)
+        raise InvalidCredentials()
+
+    jti = payload.get("jti")
+    if jti and crud.is_token_blacklisted(db, jti):
+        _log.warning("resolve_user: token jti=%s is blacklisted", jti)
+        raise InvalidCredentials()
+
+    user_id = payload.get("sub")
+    if not user_id:
+        _log.warning("resolve_user: token missing 'sub' claim")
+        raise InvalidCredentials()
+
+    user = db.query(User).filter(User.id == int(user_id)).first()
+    if not user:
+        _log.warning("resolve_user: user id=%s not found in DB", user_id)
+        raise InvalidCredentials()
+
+    token_ver = payload.get("token_version")
+    if token_ver != user.token_version:
+        _log.warning(
+            "resolve_user: token_version mismatch — token=%r db=%r user_id=%s",
+            token_ver, user.token_version, user_id,
+        )
+        raise InvalidCredentials()
+
+    return user
 
 
 def get_current_user(
     token: str = Depends(_oauth2_scheme),
     db: Session = Depends(get_db),
 ) -> User:
-    """Resolve a Bearer JWT to a User row. Raises 401 on any failure.
+    """Resolve a Bearer JWT to a User row. Raises 401 on any failure."""
+    return _resolve_user_from_token(token, db)
 
-    Checks the token blacklist so explicitly revoked tokens (e.g. after
-    /logout) are rejected even before their exp timestamp elapses.
-    """
-    from .. import crud  # local import — avoids circular module dependency
 
-    try:
-        payload = decode_token(token)
-    except Exception as exc:
-        _log.warning("get_current_user: decode_token failed — %s", exc)
-        raise InvalidCredentials()
-
-    # Reject blacklisted tokens first — before any user DB lookup so that a
-    # stolen token cannot be used after the legitimate owner logs out.
-    jti = payload.get("jti")
-    if jti and crud.is_token_blacklisted(db, jti):
-        _log.warning("get_current_user: token jti=%s is blacklisted", jti)
-        raise InvalidCredentials()
-
-    user_id = payload.get("sub")
-    if not user_id:
-        _log.warning("get_current_user: token missing 'sub' claim")
-        raise InvalidCredentials()
-
-    user = db.query(User).filter(User.id == int(user_id)).first()
-    if not user:
-        _log.warning("get_current_user: user id=%s not found in DB", user_id)
-        raise InvalidCredentials()
-
-    token_ver = payload.get("token_version")
-    if token_ver != user.token_version:
-        _log.warning(
-            "get_current_user: token_version mismatch — token=%r db=%r user_id=%s",
-            token_ver, user.token_version, user_id,
-        )
-        raise InvalidCredentials()
-
-    return user
+def get_current_user_optional(
+    token: Optional[str] = Depends(_oauth2_scheme_optional),
+    db: Session = Depends(get_db),
+) -> Optional[User]:
+    """Like get_current_user but returns None when no Authorization header is present."""
+    if token is None:
+        return None
+    return _resolve_user_from_token(token, db)
 
 
 def get_seed_access_user(

--- a/server/auth/router.py
+++ b/server/auth/router.py
@@ -15,7 +15,7 @@ from ..audit.service import record as audit
 from ..database import get_db
 from ..models import FailedAttempt, User
 from ..utils import get_client_ip
-from .dependencies import get_current_user
+from .dependencies import get_current_user, get_current_user_optional
 from .exceptions import (
     InvalidOTPCode,
     InvalidRefreshToken,
@@ -391,21 +391,35 @@ async def confirm_2fa(
     request: Request,
     body: TOTPConfirmRequest,
     db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    bearer_user: User = Depends(get_current_user_optional),
 ):
     """
     Безопасное включение 2FA с защитой от захвата учетной записи.
-    
-    Ключевые исправления:
-    1. Проверка TOTP происходит только после успешной проверки пароля
-    2. Нет утечки информации о состоянии учетной записи
+
+    Enrollment token принимается двумя способами (для совместимости):
+      1. Заголовок «Authorization: Bearer <token>» (основной способ)
+      2. Поле «mfa_token» в теле запроса (запасной, если заголовок не доступен)
     """
     start_time = time.time()
     ip_address = get_client_ip(request)
     totp_valid = False
-    
-    # Проверка текущего пароля (уже выполнена в get_current_user)
-    # Здесь мы можем быть уверены, что current_user аутентифицирован
+
+    # Resolve the authenticated user: prefer Authorization header, fall back to body.mfa_token.
+    current_user = bearer_user
+    if current_user is None:
+        if not body.mfa_token:
+            _log.warning("confirm_2fa: no Bearer token and no mfa_token in body from ip=%s", ip_address)
+            constant_time_response(start_time)
+            raise HTTPException(status_code=401, detail="Authentication required")
+        from .dependencies import _resolve_user_from_token
+        try:
+            current_user = _resolve_user_from_token(body.mfa_token, db)
+        except Exception:
+            _log.warning("confirm_2fa: mfa_token validation failed from ip=%s", ip_address)
+            constant_time_response(start_time)
+            raise HTTPException(status_code=401, detail="Authentication required")
+
+    # current_user теперь аутентифицирован через один из двух механизмов
     
     # Проверка TOTP
     # verify_hardened_otp skips when totp_enabled=False, so for the


### PR DESCRIPTION
…ody field

The Flutter client was not sending the Authorization header because the app was not rebuilt after the enrollment-token changes. Make confirm_2fa robust:

Server:
- Add get_current_user_optional (auto_error=False) so confirm_2fa does not immediately 401 when the Authorization header is absent
- confirm_2fa resolves the user from the Bearer header first; falls back to body.mfa_token so the request can succeed even without the header
- Extract shared token-validation logic into _resolve_user_from_token()

Flutter:
- two_factor_setup_dialog: send enrollment token in both Authorization header AND body.mfa_token for maximum compatibility

Root cause: app binary was not rebuilt; network capture showed content-length 30 (old format with user_id) and no Authorization header.

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1