### PR TITLE
Fix 4 real security bugs found in code review

### DIFF
--- a/server/auth/router.py
+++ b/server/auth/router.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pyotp
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
@@ -105,11 +105,15 @@ async def startup_event():
     async def periodic_cleanup():
         while True:
             await asyncio.sleep(SECURITY_PARAMS["BLOCK_CLEANUP_INTERVAL"].total_seconds())
-            # Использование db_session в фоновом режиме
             from ..database import SessionLocal
+            from ..models import UsedMFAToken
             db = SessionLocal()
             try:
                 SecurityManager.cleanup_old_blocks(db)
+                # Remove expired one-time MFA token records (TTL = 2 min, safe to purge after 10 min)
+                cutoff = datetime.now(timezone.utc) - timedelta(minutes=10)
+                db.query(UsedMFAToken).filter(UsedMFAToken.expires_at < cutoff).delete()
+                db.commit()
             finally:
                 db.close()
     
@@ -326,8 +330,8 @@ async def login_phase2(
     totp_valid = False
     
     try:
-        # Валидируем MFA токен
-        payload = validate_mfa_token(body.mfa_token)
+        # Валидируем MFA токен (atomically consumed — replay-safe)
+        payload = validate_mfa_token(body.mfa_token, db)
         user_id = int(payload["sub"])
         device_id = payload["device"]
         
@@ -340,13 +344,14 @@ async def login_phase2(
             )
         
         # Проверка TOTP
+        # verify_hardened_otp already calls handle_failed_otp_attempt on any failure,
+        # so we must NOT call it again here — doing so would double-increment the counter.
         try:
             verify_hardened_otp(db, user, body.code, ip_address)
             totp_valid = True
             reset_otp_failure_counters(user, db)
         except Exception as e:
-            handle_failed_otp_attempt(db, user, ip_address)
-            log_security_event(db, user.id, "otp_failed", 
+            log_security_event(db, user.id, "otp_failed",
                 {"error": str(e), "ip": ip_address}, ip_address)
             raise
 
@@ -429,15 +434,14 @@ async def confirm_2fa(
     try:
         totp_secret = decrypt_totp(current_user.totp_secret, current_user.id)
         totp_obj = pyotp.TOTP(totp_secret)
-        # Wide window: ±3 steps (±90 s) — covers reasonable clock drift
-        valid = totp_obj.verify(body.code, valid_window=3)
+        # valid_window=1 → ±30 s drift compensation (NIST 800-63B / RFC 6238)
+        valid = totp_obj.verify(body.code, valid_window=1)
         if not valid:
-            # Debug: show expected codes so we can tell if it's a clock/secret mismatch
             now = datetime.utcnow()
             expected = {str(offset): totp_obj.at(now + timedelta(seconds=offset))
-                        for offset in (-90, -60, -30, 0, 30, 60, 90)}
+                        for offset in (-30, 0, 30)}
             _log.warning(
-                "confirm_2fa: invalid TOTP for user_id=%s ip=%s | received=%r expected(±90s)=%s",
+                "confirm_2fa: invalid TOTP for user_id=%s ip=%s | received=%r expected(±30s)=%s",
                 current_user.id, ip_address, body.code, expected,
             )
             handle_failed_otp_attempt(db, current_user, ip_address)

--- a/server/auth/service.py
+++ b/server/auth/service.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..config import settings
-from ..models import User, RefreshToken, SecurityEvent, UsedOTP
+from ..models import User, RefreshToken, SecurityEvent, UsedOTP, UsedMFAToken
 from ..security import SecurityManager, SECURITY_PARAMS
 from ..audit.service import record as audit
 from .constants import (
@@ -209,6 +209,13 @@ def verify_hardened_otp(db: Session, user: User, otp: Optional[str], ip_address:
     if not otp:
         raise OTPRequired()
 
+    # ── Lockout check BEFORE any cryptographic work (NIST 800-63B) ──
+    if user.lockout_until and user.lockout_until > datetime.now(timezone.utc):
+        raise HTTPException(
+            status_code=423,
+            detail="Account temporarily locked. Try again later.",
+        )
+
     # ── Step 1: mathematical check (fast path — rejects wrong codes without DB) ──
     totp_secret = decrypt_totp(user.totp_secret, user.id)
     totp_obj = pyotp.TOTP(totp_secret)
@@ -266,29 +273,54 @@ def constant_time_response(start_time: float) -> None:
     SecurityManager.constant_time_delay(start_time)
 
 def create_mfa_token(user_id: int, device_id: str) -> str:
-    """Create a temporary MFA token for two-factor authentication."""
+    """Create a temporary one-time-use MFA token.  jti is stored in UsedMFAToken
+    on first use; a second attempt with the same token gets IntegrityError → 401.
+    """
     now = int(time.time())
     payload = {
         "sub": str(user_id),
         "device": device_id,
         "type": "mfa",
+        "jti": secrets.token_hex(16),  # unique ID for one-time-use enforcement
         "iat": now,
         "exp": now + 120,  # 2 minutes
     }
     return jwt.encode(payload, settings.JWT_SECRET_KEY, algorithm=settings.ALGORITHM)
 
-def validate_mfa_token(token: str) -> dict:
-    """Validate MFA token and return payload."""
+def validate_mfa_token(token: str, db: Session) -> dict:
+    """Validate MFA token and atomically mark it as used (replay protection).
+
+    Uses the same atomic-INSERT pattern as verify_hardened_otp / UsedOTP:
+    the UniqueConstraint on UsedMFAToken.jti ensures that if two concurrent
+    requests present the same token only one succeeds; the second gets an
+    IntegrityError and is rejected with 401.
+    """
+    from sqlalchemy.exc import IntegrityError
+    from datetime import timezone as _tz
+
     try:
         payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=[settings.ALGORITHM])
         if payload.get("type") != "mfa":
             raise ValueError("Invalid token type")
-        return payload
     except Exception:
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid MFA token"
-        )
+        raise HTTPException(status_code=401, detail="Invalid MFA token")
+
+    jti = payload.get("jti")
+    if not jti:
+        # Tokens without jti pre-date this change; reject them.
+        raise HTTPException(status_code=401, detail="Invalid MFA token")
+
+    exp = payload.get("exp", 0)
+    expires_at = datetime.fromtimestamp(exp, tz=_tz.utc)
+
+    try:
+        db.add(UsedMFAToken(jti=jti, expires_at=expires_at))
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=401, detail="MFA token already used")
+
+    return payload
 
 def get_device_id_from_request(request: Request) -> str:
     """Get device ID from secure cookie or generate new one."""

--- a/server/models.py
+++ b/server/models.py
@@ -190,6 +190,21 @@ class UsedOTP(Base):
     user = relationship("User")
 
 
+class UsedMFAToken(Base):
+    """One-time-use store for MFA token JTIs (prevents replay within the 2-minute window).
+    Rows with expired `expires_at` are cleaned up by the periodic cleanup task.
+    The UniqueConstraint on `jti` makes the INSERT atomic — a concurrent second
+    request using the same token gets IntegrityError and is rejected.
+    """
+    __tablename__ = "used_mfa_tokens"
+    __table_args__ = (UniqueConstraint("jti", name="uq_mfa_jti"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    jti = Column(String, nullable=False, index=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+
 class SecurityEvent(Base):
     __tablename__ = "security_events"
 


### PR DESCRIPTION
1. verify_hardened_otp: check lockout_until BEFORE any crypto work A locked-out account could still exhaust OTP attempts; now returns HTTP 423 immediately when lockout_until is in the future.

2. login_phase2: remove duplicate handle_failed_otp_attempt call verify_hardened_otp already increments the counter on failure; the surrounding try/except was calling it a second time, causing the lockout threshold to be hit at half the configured value.

3. MFA token replay protection: add jti + one-time-use DB table
   - create_mfa_token now includes a jti (secrets.token_hex(16))
   - validate_mfa_token(token, db) atomically INSERTs into new UsedMFAToken table; a second use of the same token triggers IntegrityError → 401, same pattern as UsedOTP for TOTP codes
   - Periodic cleanup removes expired rows (expires_at + 10 min buffer)

4. confirm_2fa: reduce valid_window from 3 (±90 s) to 1 (±30 s) ±90 s is unnecessarily wide for enrollment; ±30 s matches RFC 6238 and what verify_hardened_otp uses for regular login. Diagnostic log now shows ±30 s expected codes instead of ±90 s.

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1