### PR TITLE
Fix PIN save error: replace EncryptedSharedPreferences with KeyStore …

### DIFF
--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -19,7 +19,10 @@ class VaultService {
   SecretKey? _masterKey;
   final _crypto = CryptoService();
   final _cache  = CacheService();
-  final _storage = const FlutterSecureStorage();
+  final _storage = const FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: false),
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+  );
 
   static const _storageKey = 'encrypted_master_key';
   static const _saltKey    = 'master_key_salt';
@@ -102,7 +105,7 @@ class VaultService {
   /// Stores master key encrypted with PIN bytes (avoids String creation).
   /// CWE-256: PIN bytes are never converted to a Dart String.
   Future<void> storeMasterKeyWithPinBytes(Uint8List pinBytes) async {
-    if (_masterKey == null) return;
+    if (_masterKey == null) throw StateError('Vault is locked — master key not loaded');
 
     final prefs = await SharedPreferences.getInstance();
     String? salt = prefs.getString(_saltKey);

--- a/lib/utils/pin_security.dart
+++ b/lib/utils/pin_security.dart
@@ -13,7 +13,12 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 ///   CWE-284 — failed-attempt counter + lockout timestamp persisted in secure storage
 class PinSecurity {
   static const _storage = FlutterSecureStorage(
-    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    aOptions: AndroidOptions(
+      encryptedSharedPreferences: false,  // Use KeyStore+SharedPreferences (API 18+, more compatible)
+    ),
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock,
+    ),
   );
 
   // Storage keys


### PR DESCRIPTION
…backend

Root cause: PinSecurity._storage used encryptedSharedPreferences: true, which requires EncryptedSharedPreferences from androidx.security:security-crypto. This library has known initialization failures on some Android devices (bad AEADBadTagException / KeyStoreException on first-run or after app reinstall), while VaultService._storage used the default (encryptedSharedPreferences: false) which uses Android Keystore directly and is compatible with API 18+.

Fix:
- PinSecurity._storage: encryptedSharedPreferences: false + IOSOptions
- VaultService._storage: make options explicit (same backend as before)
- storeMasterKeyWithPinBytes: throw StateError when _masterKey is null instead of silently returning, so the catch block properly surfaces the real error rather than silently skipping PIN-key encryption

Both storages now use the same KeyStore + SharedPreferences backend, which is equally secure and significantly more compatible.

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1