### PR TITLE
fix: replace unsafe Uint8List downcast with Uint8List.fromList in vau…

### DIFF
--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -60,10 +60,10 @@ class VaultService {
     _masterKey = await _crypto.deriveMasterKey(password, salt);
 
     if (await BiometricService.isBiometricEnabled()) {
-      final keyBytes = await _masterKey!.extractBytes();
+      final keyBytes = Uint8List.fromList(await _masterKey!.extractBytes());
       await BiometricService.storeBiometricSecret(base64.encode(keyBytes));
       // Wipe extracted bytes immediately after use
-      (keyBytes as Uint8List).fillRange(0, keyBytes.length, 0);
+      keyBytes.fillRange(0, keyBytes.length, 0);
     }
   }
 
@@ -90,12 +90,12 @@ class VaultService {
     }
 
     final pinKey      = await _crypto.deriveMasterKey(pin, salt);
-    final keyBytes    = await _masterKey!.extractBytes();
+    final keyBytes    = Uint8List.fromList(await _masterKey!.extractBytes());
     final keyB64      = base64.encode(keyBytes);
     final encryptedKey = await _crypto.encrypt(pinKey, keyB64);
 
     // Wipe key bytes after encryption
-    (keyBytes as Uint8List).fillRange(0, keyBytes.length, 0);
+    keyBytes.fillRange(0, keyBytes.length, 0);
     // Native wipe of temporary base64 string
     await nativeWipe(keyB64);
 
@@ -117,11 +117,11 @@ class VaultService {
     }
 
     final pinKey       = await _crypto.deriveMasterKeyFromBytes(pinBytes, salt);
-    final keyBytes     = await _masterKey!.extractBytes();
+    final keyBytes     = Uint8List.fromList(await _masterKey!.extractBytes());
     final keyB64       = base64.encode(keyBytes);
     final encryptedKey = await _crypto.encrypt(pinKey, keyB64);
 
-    (keyBytes as Uint8List).fillRange(0, keyBytes.length, 0);
+    keyBytes.fillRange(0, keyBytes.length, 0);
     await nativeWipe(keyB64);
 
     await _storage.write(key: _storageKey, value: encryptedKey);


### PR DESCRIPTION
…lt key zeroing

SecretKey.extractBytes() from the cryptography package returns Future<List<int>>. On Android the runtime type may be List<int>, not Uint8List, so the pattern
  (keyBytes as Uint8List).fillRange(...)
threw a TypeError after encrypt() succeeded but before _storage.write() ran — meaning the encrypted master key was computed but never persisted, causing the PIN save error on first setup.

Fixed all three occurrences (unlock, storeMasterKeyWithPin, storeMasterKeyWithPinBytes) by wrapping the result in Uint8List.fromList() before zeroing, which is always safe regardless of the runtime subtype.

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1