### PR TITLE
fix: correct login field name mismatch and MFA endpoint routing

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -47,6 +47,7 @@ class AppConfig {
 
   // Методы для получения полных URL эндпоинтов
   static String get loginUrl => '$apiUrl/api/v1/login';
+  static String get loginMfaUrl => '$apiUrl/api/v1/login/mfa';
   static String get registerUrl => '$apiUrl/api/v1/register';
   static String get setup2faUrl => '$apiUrl/api/v1/setup_2fa';
   static String get confirm2faUrl => '$apiUrl/api/v1/confirm_2fa';

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -74,8 +74,8 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
 
       if (response.statusCode == 200) {
         final data = json.decode(response.body);
-        
-        if (data['two_fa_required'] == true) {
+
+        if (data['requires_mfa'] == true) {
           if (!mounted) return;
           final String? otpCode = await showDialog<String>(
             context: context,
@@ -83,7 +83,7 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
           );
 
           if (otpCode != null) {
-            await _loginWithOTP(login, password, otpCode);
+            await _loginWithOTP(password, otpCode, data['mfa_token'] as String);
           } else {
             setState(() => _isLoading = false);
           }
@@ -102,7 +102,8 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
         );
         _playErrorShake();
       }
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('Login error: $e\n$st');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Ошибка подключения к серверу')),
@@ -112,18 +113,16 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
     }
   }
 
-  Future<void> _loginWithOTP(String login, String password, String otp) async {
+  Future<void> _loginWithOTP(String password, String otp, String mfaToken) async {
     setState(() => _isLoading = true);
-    final devicePayload = await SecurityUtils.getDeviceSecurityPayload();
-    
+
     try {
       final response = await http.post(
-        Uri.parse(AppConfig.loginUrl),
-        headers: {'Content-Type': 'application/json', 'X-OTP': otp},
+        Uri.parse(AppConfig.loginMfaUrl),
+        headers: {'Content-Type': 'application/json'},
         body: json.encode({
-          'login': login, 
-          'password': password,
-          'device_info': devicePayload,
+          'mfa_token': mfaToken,
+          'code': otp,
         }),
       );
 


### PR DESCRIPTION
Two bugs caused 'Ошибка подключения к серверу' after server returned 200:

1. Field name mismatch: server's LoginPhase1Response uses `requires_mfa` but the client checked `data['two_fa_required']` (always null). For users with 2FA: phase-1 200 has no `access_token`, so `prefs.setString('token', null)` threw TypeError → caught by the generic catch → misleading network-error message.

2. Wrong MFA endpoint: _loginWithOTP sent the OTP as an X-OTP header to /api/v1/login, but the server expects {mfa_token, code} in the body at /api/v1/login/mfa (TOTPConfirmRequest schema).

Fixes:
- Check `data['requires_mfa']` instead of `data['two_fa_required']`
- Add `loginMfaUrl` to AppConfig pointing to /api/v1/login/mfa
- Rewrite _loginWithOTP to POST {mfa_token, code} to loginMfaUrl
- Pass mfa_token from phase-1 response through to phase-2 call
- Add debugPrint to login catch block for future diagnostics

https://claude.ai/code/session_015rsxteDF9UVSvrkovxQMJ1