### PR TITLE
Fix login: server returns 401 for invalid credentials instead of 200

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -90,11 +90,22 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
           return;
         }
 
+        if (data['access_token'] == null) {
+          if (!mounted) return;
+          _formKey.currentState?.fields['password']?.invalidate('Неверный логин или пароль');
+          _playErrorShake();
+          return;
+        }
+
         await _handleSuccessfulLogin(data, password);
+      } else if (response.statusCode == 401) {
+        if (!mounted) return;
+        _formKey.currentState?.fields['password']?.invalidate('Неверный логин или пароль');
+        _playErrorShake();
       } else {
         final error = ServerError.fromJson(response.body, response.statusCode);
         if (!mounted) return;
-        
+
         FormErrorHandler.applyErrors(
           formKey: _formKey,
           error: error,

--- a/server/auth/router.py
+++ b/server/auth/router.py
@@ -205,13 +205,11 @@ async def login_phase1(
         if attempts >= BRUTE_FORCE_MAX:
              SecurityManager.block_ip(db, ip_address, timedelta(hours=3))
             
-        log_security_event(db, user.id if user else None, "failed_login", 
+        log_security_event(db, user.id if user else None, "failed_login",
             {"user_exists": user_exists, "ip": ip_address, "attempts": attempts}, ip_address)
-        
-        response = LoginPhase1Response(
-            requires_mfa=False,
-            salt=secrets.token_hex(16)
-        )
+
+        constant_time_response(start_time)
+        raise HTTPException(status_code=401, detail="Invalid credentials")
     else:
         # Успех
         log_security_event(db, user.id, "password_verified", {"ip": ip_address}, ip_address)


### PR DESCRIPTION
Previously the server returned HTTP 200 with an empty LoginPhase1Response (no access_token) for wrong passwords. Flutter checked only statusCode==200, called _handleSuccessfulLogin with null access_token, which crashed silently and showed "Ошибка подключения к серверу" instead of navigating to the account.

Fix:
- server/auth/router.py: raise HTTPException(401) after constant_time_response when password is invalid, instead of returning a 200 with no token
- lib/screens/login_screen.dart: handle 401 explicitly with field-level error "Неверный логин или пароль", plus null-guard on access_token for safety

https://claude.ai/code/session_01M9m9dYToWcRWx6f5xeujcT