### PR TITLE
No-PIN cold restart, biometric TOTP gate, and manifest permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,14 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
 
+    <!-- Biometric hardware feature declarations (optional — app works without them) -->
+    <uses-feature
+        android:name="android.hardware.fingerprint"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.biometrics.face"
+        android:required="false" />
+
     <!-- Internet access for API calls -->
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -499,7 +499,102 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _toggleBiometric(bool value) async {
     if (value) {
-      // Включаем биометрическую аутентификацию — сохраняем мастер-ключ в биометрическое хранилище
+      // ── Step 1: Verify TOTP before storing the master key biometrically ───────
+      final totpController = TextEditingController();
+      final String? otp = await showDialog<String>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          backgroundColor: AppColors.input,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          title: Text(
+            'Подтверждение TOTP',
+            style: TextStyle(color: AppColors.text, fontWeight: FontWeight.bold),
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.fingerprint, size: 48, color: AppColors.button),
+              const SizedBox(height: 12),
+              Text(
+                'Для включения биометрической аутентификации введите TOTP-код из приложения-аутентификатора.',
+                style: TextStyle(color: AppColors.text.withOpacity(0.75), fontSize: 13),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: totpController,
+                autofocus: true,
+                keyboardType: TextInputType.number,
+                maxLength: 6,
+                style: TextStyle(color: AppColors.text, fontSize: 20, letterSpacing: 4),
+                textAlign: TextAlign.center,
+                decoration: InputDecoration(
+                  hintText: '000000',
+                  hintStyle: TextStyle(color: AppColors.text.withOpacity(0.3)),
+                  counterText: '',
+                  filled: true,
+                  fillColor: AppColors.background,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(color: AppColors.button.withOpacity(0.4)),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: BorderSide(color: AppColors.button, width: 2),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: Text('Отмена', style: TextStyle(color: AppColors.text.withOpacity(0.6))),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(backgroundColor: AppColors.button),
+              onPressed: () => Navigator.pop(ctx, totpController.text.trim()),
+              child: const Text('Подтвердить', style: TextStyle(color: Colors.white)),
+            ),
+          ],
+        ),
+      );
+
+      if (otp == null || otp.isEmpty) return;
+
+      // ── Step 2: Verify OTP server-side ────────────────────────────────────────
+      try {
+        final verifyResp = await http.post(
+          Uri.parse(AppConfig.verifyTotpUrl),
+          headers: {
+            'X-OTP': otp,
+            'Authorization': 'Bearer ${(await SharedPreferences.getInstance()).getString('token') ?? ''}',
+          },
+        );
+        if (verifyResp.statusCode != 200) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                backgroundColor: Colors.red,
+                content: Text('Неверный TOTP-код. Биометрия не включена.'),
+              ),
+            );
+          }
+          return;
+        }
+      } catch (_) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              backgroundColor: Colors.red,
+              content: Text('Ошибка проверки TOTP. Проверьте соединение.'),
+            ),
+          );
+        }
+        return;
+      }
+
+      // ── Step 3: Store master key in biometric keystore ────────────────────────
       try {
         final vault = VaultService();
         if (vault.isLocked) {
@@ -516,22 +611,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
         final keyBytes = await vault.masterKey!.extractBytes();
         final keyB64 = base64.encode(keyBytes);
-        // Zero raw bytes immediately after encoding
         (keyBytes as Uint8List).fillRange(0, keyBytes.length, 0);
 
         final stored = await BiometricService.storeBiometricSecret(keyB64);
 
         if (stored) {
           await BiometricService.setBiometricEnabled(true);
-          setState(() {
-            _biometricEnabled = true;
-          });
+          setState(() => _biometricEnabled = true);
 
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 backgroundColor: Colors.green,
-                content: Text('$_biometricType включен'),
+                content: Text('$_biometricType включён'),
               ),
             );
           }
@@ -540,7 +632,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(
                 backgroundColor: Colors.red,
-                content: Text('Аутентификация не пройдена'),
+                content: Text('Биометрическая аутентификация не пройдена'),
               ),
             );
           }
@@ -550,9 +642,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
               backgroundColor: Colors.red,
-              content: Text(
-                'Ошибка при включении биометрической аутентификации',
-              ),
+              content: Text('Ошибка при включении биометрической аутентификации'),
             ),
           );
         }

--- a/lib/screens/setup_pin_screen.dart
+++ b/lib/screens/setup_pin_screen.dart
@@ -145,6 +145,9 @@ class _SetupPinScreenState extends State<SetupPinScreen>
       // 2. Encrypt master key with PIN bytes — no String creation (CWE-256)
       await VaultService().storeMasterKeyWithPinBytes(_pinBytes);
 
+      // 3. Remove no-PIN key if it existed (user now has a PIN).
+      await VaultService().clearNoPinMasterKey();
+
       // 3. Zero PIN bytes after all operations
       _pinBytes.fillRange(0, _pinBytes.length, 0);
       _pinBytes = Uint8List(0);
@@ -341,12 +344,17 @@ class _SetupPinScreenState extends State<SetupPinScreen>
 
                   if (!_isConfirming)
                     TextButton(
-                      onPressed: () {
-                        Navigator.pushNamedAndRemoveUntil(
-                          context,
-                          '/passwords',
-                          (route) => false,
-                        );
+                      onPressed: () async {
+                        // Persist master key using device keystore so user can
+                        // re-enter the app without PIN on cold restart.
+                        await VaultService().storeNoPinMasterKey();
+                        if (mounted) {
+                          Navigator.pushNamedAndRemoveUntil(
+                            context,
+                            '/passwords',
+                            (route) => false,
+                          );
+                        }
                       },
                       child: const Text(
                         'Пропустить',

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -3,10 +3,12 @@ import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:safe_device/safe_device.dart';
 import 'package:nk3_zero/screens/login_screen.dart';
+import 'package:nk3_zero/screens/passwords_screen.dart';
 import 'package:nk3_zero/screens/pin_screen.dart';
 import 'package:nk3_zero/screens/setup_pin_screen.dart';
 import '../config/app_config.dart';
 import '../utils/pin_security.dart';
+import '../services/vault_service.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
@@ -63,23 +65,29 @@ class _SplashScreenState extends State<SplashScreen> {
       return;
     }
 
+    Widget destination;
+    if (token != null) {
+      if (hasPinHash) {
+        // User has a PIN → go to PIN screen to unlock vault.
+        destination = const PinScreen();
+      } else {
+        // No PIN set — try to restore master key from device keystore
+        // (stored when user pressed "Skip" on SetupPinScreen).
+        final restored = await VaultService().loadNoPinMasterKey();
+        if (restored) {
+          destination = const PasswordsScreen();
+        } else {
+          // Key not persisted (e.g. fresh install after logout) — need login.
+          destination = const LoginScreen();
+        }
+      }
+    } else {
+      destination = const LoginScreen();
+    }
+
+    if (!mounted) return;
     Navigator.of(context).pushReplacement(
-      MaterialPageRoute(
-        builder: (context) {
-          if (token != null) {
-            if (hasPinHash) {
-              return const PinScreen();
-            } else {
-              // No PIN stored → vault cannot be unlocked from local storage.
-              // Send user to login so they re-derive the master key from their
-              // password. SetupPinScreen will be offered after a successful login.
-              return const LoginScreen();
-            }
-          } else {
-            return const LoginScreen();
-          }
-        },
-      ),
+      MaterialPageRoute(builder: (_) => destination),
     );
   }
 

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -165,6 +165,36 @@ class VaultService {
     }
   }
 
+  // ── No-PIN master key storage (device-keystore backed, no user secret) ───────
+  // Used when the user opts out of PIN — the master key is still protected by
+  // the Android Keystore / iOS Secure Enclave at the OS level.
+  static const _noPinStorageKey = 'master_key_no_pin';
+
+  /// Persist master key without a user PIN. Only call when the vault is unlocked.
+  Future<void> storeNoPinMasterKey() async {
+    if (_masterKey == null) return;
+    final keyBytes = Uint8List.fromList(await _masterKey!.extractBytes());
+    await _storage.write(key: _noPinStorageKey, value: base64.encode(keyBytes));
+    keyBytes.fillRange(0, keyBytes.length, 0);
+  }
+
+  /// Restore master key from no-PIN storage. Returns true on success.
+  Future<bool> loadNoPinMasterKey() async {
+    final stored = await _storage.read(key: _noPinStorageKey);
+    if (stored == null) return false;
+    try {
+      _masterKey = SecretKey(base64.decode(stored));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Erase no-PIN master key (call after user sets up PIN or logs out).
+  Future<void> clearNoPinMasterKey() async {
+    await _storage.delete(key: _noPinStorageKey);
+  }
+
   Future<void> clearAllData() async {
     lock();
 


### PR DESCRIPTION
- vault_service: add storeNoPinMasterKey/loadNoPinMasterKey/clearNoPinMasterKey — persists master key in device keystore (FlutterSecureStorage, hardware-backed) when user opts out of PIN, so cold restart skips login screen
- setup_pin_screen: Skip button now calls storeNoPinMasterKey() before navigating; PIN setup calls clearNoPinMasterKey() so only one credential path is active
- splash_screen: when token exists but no PIN hash, try loadNoPinMasterKey() and route to PasswordsScreen on success instead of LoginScreen
- settings_screen: _toggleBiometric now requires TOTP verification (dialog + server-side check at /api/v1/verify-totp) before storing master key in biometric keystore — prevents unauthorized biometric enrollment
- AndroidManifest: add android.hardware.fingerprint and android.hardware.biometrics.face feature declarations (required=false) alongside existing USE_BIOMETRIC/USE_FINGERPRINT permissions; minSdk=23 already satisfies BiometricPrompt minimum API requirement

https://claude.ai/code/session_01M9m9dYToWcRWx6f5xeujcT