### PR TITLE
Secure token storage, seed-phrase metadata, and memory/security hardening

### DIFF
--- a/android/app/src/main/kotlin/com/example/nk3_zero/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/nk3_zero/MainActivity.kt
@@ -5,6 +5,7 @@ package com.example.nk3_zero
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import android.view.WindowManager
 
 /**
  * Main Flutter activity.
@@ -26,6 +27,10 @@ class MainActivity : FlutterFragmentActivity() {
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE,
+        )
 
         MethodChannel(
             flutterEngine.dartExecutor.binaryMessenger,

--- a/lib/screens/add_password_screen.dart
+++ b/lib/screens/add_password_screen.dart
@@ -215,6 +215,9 @@ class _AddPasswordScreenState extends State<AddPasswordScreen>
         login: email,
         password: password,
         notes: notesController.text.trim().isNotEmpty ? notesController.text.trim() : null,
+        seedPhrase: hasSeedPhrase && seedPhraseController.text.trim().isNotEmpty
+            ? seedPhraseController.text.trim()
+            : null,
         folderId: _selectedFolderId,
       );
 

--- a/lib/screens/edit_password_screen.dart
+++ b/lib/screens/edit_password_screen.dart
@@ -10,6 +10,7 @@ import '../utils/api_service.dart';
 import '../utils/memory_security.dart';
 import '../utils/password_history_service.dart';
 import '../utils/folder_service.dart';
+import '../services/auth_token_storage.dart';
 import '../services/vault_service.dart';
 
 // ── helpers (same as add_password_screen) ────────────────────────────────────
@@ -101,7 +102,7 @@ class _EditPasswordScreenState extends State<EditPasswordScreen> {
     try {
       final encPayload = widget.password['encrypted_payload'] as String?;
       final encNotes   = widget.password['notes_encrypted']   as String?;
-      final encSeed    = widget.password['seed_phrase_encrypted'] as String?;
+      final encMeta    = widget.password['encrypted_metadata'] as String?;
 
       if (encPayload != null) {
         passwordController.text = await VaultService().decryptPayload(encPayload);
@@ -109,8 +110,11 @@ class _EditPasswordScreenState extends State<EditPasswordScreen> {
       if (encNotes != null) {
         notesController.text = await VaultService().decryptPayload(encNotes);
       }
-      if (encSeed != null) {
-        seedPhraseController.text = await VaultService().decryptPayload(encSeed);
+      final decryptedSeed =
+          await VaultService().decryptSeedPhraseFromMetadata(encMeta);
+      if (decryptedSeed != null) {
+        seedPhraseController.text = decryptedSeed;
+        unawaited(nativeWipe(decryptedSeed));
       }
       if (mounted) setState(() => _passwordDecrypted = true);
     } catch (e) {
@@ -274,8 +278,10 @@ class _EditPasswordScreenState extends State<EditPasswordScreen> {
     });
 
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final token = prefs.getString('token');
+      final token = await AuthTokenStorage.readAccessToken();
+      if (token == null || token.isEmpty) {
+        throw Exception('Missing access token');
+      }
 
       final passwordId = widget.password['id'];
 

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -2,13 +2,13 @@ import 'package:flutter/material.dart';
 import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import '../theme/colors.dart';
 import '../config/app_config.dart';
 import '../widgets/otp_input_dialog.dart';
+import '../services/auth_token_storage.dart';
 import '../utils/passkey_service.dart';
 import '../services/vault_service.dart';
 import '../models/server_error.dart';
@@ -155,8 +155,7 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
   }
 
   Future<void> _handleSuccessfulLogin(Map<String, dynamic> data, String password) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('token', data['access_token']);
+    await AuthTokenStorage.writeAccessToken(data['access_token'] as String);
 
     final salt = data['salt'];
     if (salt != null) {
@@ -188,8 +187,7 @@ class _LoginScreenState extends State<LoginScreen> with SingleTickerProviderStat
       final data = await _passkeyService.loginWithPasskey(deviceId);
 
       if (data != null && data['access_token'] != null) {
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setString('token', data['access_token']);
+        await AuthTokenStorage.writeAccessToken(data['access_token'] as String);
 
         if (!mounted) return;
         final hasPinHash = await PinSecurity.hasPinHash();

--- a/lib/screens/password_detail_screen.dart
+++ b/lib/screens/password_detail_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import '../theme/colors.dart';
 import '../widgets/themed_widgets.dart';
 import '../utils/memory_security.dart';
@@ -8,15 +7,11 @@ import '../services/vault_service.dart';
 import 'edit_password_screen.dart';
 
 /// Shows the detail of a single password account.
-/// The plaintext password is never held as a String in a field —
-/// it lives in a [SecureBuffer] that is wiped when the screen is popped.
-///
-/// Navigation flow:
-///   PasswordsScreen → PasswordDetailScreen → (optional) EditPasswordScreen
+/// Sensitive fields are decrypted only on demand and wiped again when hidden.
 class PasswordDetailScreen extends StatefulWidget {
   /// Metadata-only map from [VaultService.loadPasswordList].
   /// Must contain: id, title, subtitle, encrypted_payload (optional),
-  /// has_2fa, has_seed_phrase, notes_encrypted, seed_phrase_encrypted.
+  /// has_2fa, has_seed_phrase, notes_encrypted, encrypted_metadata.
   final Map<String, dynamic> entry;
 
   const PasswordDetailScreen({super.key, required this.entry});
@@ -26,22 +21,20 @@ class PasswordDetailScreen extends StatefulWidget {
 }
 
 class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
-  // Secure buffers for sensitive data — wiped in dispose()
-  SecureBuffer? _passwordBuf;
-  SecureBuffer? _notesBuf;
-  SecureBuffer? _seedBuf;
-
-  bool _isLoading  = true;
-  bool _showPwd    = false;
-  bool _showNotes  = false;
-  bool _showSeed   = false;
-  bool _copied     = false;
+  bool _isLoading = true;
+  bool _showPwd = false;
+  bool _showNotes = false;
+  bool _showSeed = false;
+  bool _copied = false;
   String? _errorMsg;
 
-  // Cached decoded strings — only live in memory while screen is active
-  String _pwdDisplay   = '';
+  String? _encryptedPayload;
+  String? _encryptedNotes;
+  String? _encryptedMetadata;
+
+  String _pwdDisplay = '';
   String _notesDisplay = '';
-  String _seedDisplay  = '';
+  String _seedDisplay = '';
 
   @override
   void initState() {
@@ -55,13 +48,13 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
     super.dispose();
   }
 
-  // ── Load ──────────────────────────────────────────────────────────────────
-
   Future<void> _loadSensitiveData() async {
-    setState(() { _isLoading = true; _errorMsg = null; });
+    setState(() {
+      _isLoading = true;
+      _errorMsg = null;
+    });
 
     try {
-      // If the list-view entry had no encrypted_payload, fetch the full entry
       Map<String, dynamic> full = widget.entry;
       if (full['encrypted_payload'] == null) {
         final id = full['id'] as int?;
@@ -70,57 +63,161 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
         }
       }
 
-      final encPayload = full['encrypted_payload'] as String?;
-      final encNotes   = full['notes_encrypted']   as String?;
-      final encSeed    = full['seed_phrase_encrypted'] as String?;
-
-      if (encPayload != null) {
-        _passwordBuf = await VaultService().decryptPayloadSecure(encPayload);
-        _pwdDisplay  = String.fromCharCodes(_passwordBuf!.getBytesCopy());
-      }
-      if (encNotes != null) {
-        _notesBuf    = await VaultService().decryptPayloadSecure(encNotes);
-        _notesDisplay = String.fromCharCodes(_notesBuf!.getBytesCopy());
-      }
-      if (encSeed != null) {
-        _seedBuf     = await VaultService().decryptPayloadSecure(encSeed);
-        _seedDisplay = String.fromCharCodes(_seedBuf!.getBytesCopy());
-      }
+      _encryptedPayload = full['encrypted_payload'] as String?;
+      _encryptedNotes = full['notes_encrypted'] as String?;
+      _encryptedMetadata = full['encrypted_metadata'] as String?;
     } catch (e) {
       _errorMsg = 'Ошибка расшифровки: $e';
     } finally {
-      if (mounted) setState(() => _isLoading = false);
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
     }
   }
 
   void _wipeAllBuffers() {
-    _passwordBuf?.wipe();
-    _notesBuf?.wipe();
-    _seedBuf?.wipe();
-    // Overwrite display strings (best-effort — Dart Strings are immutable)
-    if (_pwdDisplay.isNotEmpty) unawaited(wipeController(TextEditingController(text: _pwdDisplay)));
-    if (_notesDisplay.isNotEmpty) unawaited(wipeController(TextEditingController(text: _notesDisplay)));
-    if (_seedDisplay.isNotEmpty) unawaited(wipeController(TextEditingController(text: _seedDisplay)));
-    
-    _pwdDisplay   = '';
+    _wipeDisplayedValue(_pwdDisplay);
+    _wipeDisplayedValue(_notesDisplay);
+    _wipeDisplayedValue(_seedDisplay);
+    _pwdDisplay = '';
     _notesDisplay = '';
-    _seedDisplay  = '';
+    _seedDisplay = '';
   }
 
-  // ── Actions ───────────────────────────────────────────────────────────────
+  void _wipeDisplayedValue(String value) {
+    if (value.isEmpty) return;
+    unawaited(wipeController(TextEditingController(text: value)));
+  }
 
   Future<void> _copyPassword() async {
-    if (_passwordBuf == null) return;
-    await copySecureBuffer(_passwordBuf!);
+    if (_encryptedPayload == null || _encryptedPayload!.isEmpty) return;
+
+    final passwordBuf = await VaultService().decryptPayloadSecure(_encryptedPayload!);
+    try {
+      await copySecureBuffer(passwordBuf);
+    } finally {
+      passwordBuf.wipe();
+    }
+
+    if (!mounted) return;
     setState(() => _copied = true);
     Future.delayed(const Duration(seconds: 2), () {
       if (mounted) setState(() => _copied = false);
     });
   }
 
+  Future<void> _togglePasswordVisibility() async {
+    if (_showPwd) {
+      _wipeDisplayedValue(_pwdDisplay);
+      if (!mounted) return;
+      setState(() {
+        _showPwd = false;
+        _pwdDisplay = '';
+      });
+      return;
+    }
+
+    if (_encryptedPayload == null || _encryptedPayload!.isEmpty) return;
+
+    try {
+      final passwordBuf = await VaultService().decryptPayloadSecure(_encryptedPayload!);
+      final bytes = passwordBuf.getBytesCopy();
+      final display = String.fromCharCodes(bytes);
+      bytes.fillRange(0, bytes.length, 0);
+      passwordBuf.wipe();
+
+      if (!mounted) {
+        await nativeWipe(display);
+        return;
+      }
+
+      setState(() {
+        _pwdDisplay = display;
+        _showPwd = true;
+      });
+    } catch (e) {
+      if (mounted) {
+        setState(() => _errorMsg = 'Ошибка расшифровки: $e');
+      }
+    }
+  }
+
+  Future<void> _toggleNotesVisibility() async {
+    if (_showNotes) {
+      _wipeDisplayedValue(_notesDisplay);
+      if (!mounted) return;
+      setState(() {
+        _showNotes = false;
+        _notesDisplay = '';
+      });
+      return;
+    }
+
+    if (_encryptedNotes == null || _encryptedNotes!.isEmpty) return;
+
+    try {
+      final notesBuf = await VaultService().decryptPayloadSecure(_encryptedNotes!);
+      final bytes = notesBuf.getBytesCopy();
+      final display = String.fromCharCodes(bytes);
+      bytes.fillRange(0, bytes.length, 0);
+      notesBuf.wipe();
+
+      if (!mounted) {
+        await nativeWipe(display);
+        return;
+      }
+
+      setState(() {
+        _notesDisplay = display;
+        _showNotes = true;
+      });
+    } catch (e) {
+      if (mounted) {
+        setState(() => _errorMsg = 'Ошибка расшифровки: $e');
+      }
+    }
+  }
+
+  Future<void> _toggleSeedVisibility() async {
+    if (_showSeed) {
+      _wipeDisplayedValue(_seedDisplay);
+      if (!mounted) return;
+      setState(() {
+        _showSeed = false;
+        _seedDisplay = '';
+      });
+      return;
+    }
+
+    if (_encryptedMetadata == null || _encryptedMetadata!.isEmpty) return;
+
+    try {
+      final seedBuf =
+          await VaultService().decryptSeedPhraseFromMetadataSecure(_encryptedMetadata!);
+      if (seedBuf == null) return;
+
+      final bytes = seedBuf.getBytesCopy();
+      final display = String.fromCharCodes(bytes);
+      bytes.fillRange(0, bytes.length, 0);
+      seedBuf.wipe();
+
+      if (!mounted) {
+        await nativeWipe(display);
+        return;
+      }
+
+      setState(() {
+        _seedDisplay = display;
+        _showSeed = true;
+      });
+    } catch (e) {
+      if (mounted) {
+        setState(() => _errorMsg = 'Ошибка расшифровки: $e');
+      }
+    }
+  }
+
   void _openEdit() {
-    // Pass the encrypted entry (NOT the decrypted password)
-    // EditPasswordScreen will decrypt on-demand when the user needs it
     Navigator.push<bool>(
       context,
       MaterialPageRoute(
@@ -128,21 +225,18 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
       ),
     ).then((changed) {
       if (changed == true && mounted) {
-        // Re-load if the password was changed
         _wipeAllBuffers();
         _loadSensitiveData();
       }
     });
   }
 
-  // ── Build ──────────────────────────────────────────────────────────────────
-
   @override
   Widget build(BuildContext context) {
-    final entry   = widget.entry;
-    final title   = entry['title']    as String? ?? '';
-    final login   = entry['subtitle'] as String? ?? '';
-    final has2fa  = entry['has_2fa']  as bool? ?? false;
+    final entry = widget.entry;
+    final title = entry['title'] as String? ?? '';
+    final login = entry['subtitle'] as String? ?? '';
+    final has2fa = entry['has_2fa'] as bool? ?? false;
     final hasSeed = entry['has_seed_phrase'] as bool? ?? false;
 
     return ThemedBackground(
@@ -174,48 +268,36 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
                 child: ListView(
                   padding: const EdgeInsets.fromLTRB(20, 16, 20, 40),
                   children: [
-                    // ── Header card ──────────────────────────────────────────
                     _buildHeaderCard(title, login),
                     const SizedBox(height: 20),
-
-                    // ── Error ────────────────────────────────────────────────
                     if (_errorMsg != null) ...[
                       _ErrorBanner(message: _errorMsg!),
                       const SizedBox(height: 16),
                     ],
-
-                    // ── Password card ────────────────────────────────────────
-                    if (_pwdDisplay.isNotEmpty)
-                      _buildPasswordCard(),
+                    if ((_encryptedPayload ?? '').isNotEmpty) _buildPasswordCard(),
                     const SizedBox(height: 12),
-
-                    // ── Flags ────────────────────────────────────────────────
                     Row(children: [
                       if (has2fa) _FlagChip(icon: Icons.security, label: '2FA'),
                       if (has2fa && hasSeed) const SizedBox(width: 8),
                       if (hasSeed) _FlagChip(icon: Icons.grain, label: 'Seed'),
                     ]),
                     if (has2fa || hasSeed) const SizedBox(height: 12),
-
-                    // ── Notes card ───────────────────────────────────────────
-                    if (_notesDisplay.isNotEmpty)
+                    if ((_encryptedNotes ?? '').isNotEmpty)
                       _buildRevealCard(
                         icon: Icons.notes,
                         label: 'Заметки',
                         content: _notesDisplay,
                         revealed: _showNotes,
-                        onToggle: () => setState(() => _showNotes = !_showNotes),
+                        onToggle: _toggleNotesVisibility,
                       ),
-
-                    // ── Seed phrase card ─────────────────────────────────────
-                    if (_seedDisplay.isNotEmpty) ...[
+                    if ((_encryptedMetadata ?? '').isNotEmpty && hasSeed) ...[
                       const SizedBox(height: 12),
                       _buildRevealCard(
                         icon: Icons.grain,
                         label: 'Seed-фраза',
                         content: _seedDisplay,
                         revealed: _showSeed,
-                        onToggle: () => setState(() => _showSeed = !_showSeed),
+                        onToggle: _toggleSeedVisibility,
                         highValue: true,
                       ),
                     ],
@@ -232,7 +314,6 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
         padding: const EdgeInsets.all(20),
         child: Row(
           children: [
-            // Favicon / initial
             Container(
               width: 52,
               height: 52,
@@ -266,7 +347,6 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
                 ],
               ),
             ),
-            // Copy login
             if (login.isNotEmpty)
               IconButton(
                 icon: Icon(Icons.copy, size: 18, color: AppColors.text.withOpacity(0.5)),
@@ -308,7 +388,7 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
                   child: AnimatedSwitcher(
                     duration: const Duration(milliseconds: 250),
                     child: Text(
-                      _showPwd ? _pwdDisplay : '•' * _pwdDisplay.length.clamp(8, 24),
+                      _showPwd ? _pwdDisplay : '•' * (_pwdDisplay.isEmpty ? 12 : _pwdDisplay.length.clamp(8, 24)),
                       key: ValueKey(_showPwd),
                       style: TextStyle(
                         color: AppColors.text,
@@ -319,17 +399,15 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
                     ),
                   ),
                 ),
-                // Reveal toggle
                 IconButton(
                   icon: Icon(
                     _showPwd ? Icons.visibility_off : Icons.visibility,
                     color: AppColors.text.withOpacity(0.5),
                     size: 20,
                   ),
-                  onPressed: () => setState(() => _showPwd = !_showPwd),
+                  onPressed: _togglePasswordVisibility,
                   tooltip: _showPwd ? 'Скрыть' : 'Показать',
                 ),
-                // Copy
                 AnimatedSwitcher(
                   duration: const Duration(milliseconds: 200),
                   child: IconButton(
@@ -356,7 +434,7 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
     required String label,
     required String content,
     required bool revealed,
-    required VoidCallback onToggle,
+    required Future<void> Function() onToggle,
     bool highValue = false,
   }) {
     return ThemedContainer(
@@ -364,20 +442,28 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           InkWell(
-            onTap: onToggle,
+            onTap: () => unawaited(onToggle()),
             borderRadius: BorderRadius.circular(12),
             child: Padding(
               padding: const EdgeInsets.all(16),
               child: Row(
                 children: [
-                  Icon(icon, size: 15,
-                      color: highValue ? AppColors.error.withOpacity(0.8) : AppColors.button.withOpacity(0.8)),
+                  Icon(
+                    icon,
+                    size: 15,
+                    color: highValue
+                        ? AppColors.error.withOpacity(0.8)
+                        : AppColors.button.withOpacity(0.8),
+                  ),
                   const SizedBox(width: 6),
-                  Text(label,
-                      style: TextStyle(
-                          color: AppColors.text.withOpacity(0.7),
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600)),
+                  Text(
+                    label,
+                    style: TextStyle(
+                      color: AppColors.text.withOpacity(0.7),
+                      fontSize: 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
                   const Spacer(),
                   Icon(
                     revealed ? Icons.expand_less : Icons.expand_more,
@@ -405,8 +491,6 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
     );
   }
 }
-
-// ── Small UI widgets ────────────────────────────────────────────────────────
 
 class _FlagChip extends StatelessWidget {
   final IconData icon;

--- a/lib/screens/passwords_screen.dart
+++ b/lib/screens/passwords_screen.dart
@@ -15,6 +15,7 @@ import 'folders_screen.dart';
 import '../config/app_config.dart';
 import '../utils/folder_service.dart';
 import '../utils/hidden_folder_service.dart';
+import '../services/auth_token_storage.dart';
 import '../services/vault_service.dart';
 import '../utils/memory_security.dart';
 import 'password_detail_screen.dart';
@@ -158,8 +159,8 @@ class _PasswordsScreenState extends State<PasswordsScreen> with RouteAware {
             'site_url':         item['site_url']  ?? '',
             // Keep encrypted payload for on-demand decryption in PasswordDetailScreen
             'encrypted_payload':      item['encrypted_payload'],
+            'encrypted_metadata':     item['encrypted_metadata'],
             'notes_encrypted':        item['notes_encrypted'],
-            'seed_phrase_encrypted':  item['seed_phrase_encrypted'],
             'has_2fa':          item['has_2fa']          ?? false,
             'has_seed_phrase':  item['has_seed_phrase']  ?? false,
             // Always use local assignment; fall back to server value if no local mapping.
@@ -281,8 +282,14 @@ class _PasswordsScreenState extends State<PasswordsScreen> with RouteAware {
     });
 
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final token = prefs.getString('token');
+      final token = await AuthTokenStorage.readAccessToken();
+      if (token == null || token.isEmpty) {
+        setState(() {
+          searchResults.clear();
+          isSearching = false;
+        });
+        return;
+      }
 
       final response = await http.get(
         Uri.parse(
@@ -301,8 +308,8 @@ class _PasswordsScreenState extends State<PasswordsScreen> with RouteAware {
             'subtitle':        item['site_login'] ?? '',
             // Store only encrypted payload — never plaintext
             'encrypted_payload':     item['encrypted_payload'],
+            'encrypted_metadata':    item['encrypted_metadata'],
             'notes_encrypted':       item['notes_encrypted'],
-            'seed_phrase_encrypted': item['seed_phrase_encrypted'],
             'has_2fa':         item['has_2fa'] ?? false,
             'has_seed_phrase': item['has_seed_phrase'] ?? false,
             'favicon_url':     item['favicon_url'],
@@ -392,26 +399,6 @@ class _PasswordsScreenState extends State<PasswordsScreen> with RouteAware {
         );
       }
     }
-  }
-
-  void _copySeedPhrase(String seedPhrase) {
-    if (seedPhrase.isEmpty) return;
-    Clipboard.setData(ClipboardData(text: seedPhrase));
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        backgroundColor: AppColors.accent,
-        content: const Row(
-          children: [
-            Icon(Icons.check_circle, color: Colors.white),
-            SizedBox(width: 10),
-            Text(
-              'Seed фраза скопирована в буфер обмена',
-              style: TextStyle(color: Colors.white),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 
   // ── navigation ──────────────────────────────────────────────────────────────
@@ -1756,9 +1743,8 @@ class _PasswordsScreenState extends State<PasswordsScreen> with RouteAware {
                       if (item['has_seed_phrase'] == true) ...[
                         IconButton(
                           icon: Icon(Icons.vpn_key, color: AppColors.button),
-                          onPressed:
-                              () => _copySeedPhrase(item['seed_phrase'] ?? ''),
-                          tooltip: 'Копировать seed фразу',
+                          onPressed: () => _navigateToDetail(item),
+                          tooltip: 'Открыть запись с seed-фразой',
                         ),
                         const SizedBox(width: 12),
                       ],

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'dart:typed_data';
+import 'package:bip39/bip39.dart' as bip39;
 import '../theme/colors.dart';
 import '../config/app_config.dart';
 import '../utils/biometric_service.dart';
@@ -11,11 +12,13 @@ import '../utils/pin_security.dart';
 import 'package:nk3_zero/utils/api_service.dart';
 import 'dart:io';
 import 'package:device_info_plus/device_info_plus.dart';
+import '../services/auth_token_storage.dart';
 import '../services/vault_service.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:csv/csv.dart';
 import 'package:flutter/services.dart';
 import '../utils/hidden_folder_service.dart';
+import '../utils/memory_security.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -405,8 +408,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _updateFavicons() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final token = prefs.getString('token');
+      final token = await AuthTokenStorage.readAccessToken();
+      if (token == null || token.isEmpty) {
+        _showError('Сессия истекла, войдите снова');
+        return;
+      }
 
       final response = await http.post(
         Uri.parse(AppConfig.updateFaviconsUrl),
@@ -1036,8 +1042,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           _hasSeedPhrase = data['has_seed_phrase'] ?? false;
         });
       }
-    } catch (e) {
-      print('Error loading profile: $e');
+    } catch (_) {
     } finally {
       setState(() => _isProfileLoading = false);
     }
@@ -1190,9 +1195,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       if (response.statusCode == 200) {
         _loadDevices();
       }
-    } catch (e) {
-      print('Error revoking device: $e');
-    }
+    } catch (_) {}
   }
 
   @override
@@ -1665,80 +1668,106 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _viewSeedPhrase() async {
     final TextEditingController totpController = TextEditingController();
-    
-    // 1. Show TOTP prompt
-    final String? otp = await showDialog<String>(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: AppColors.input,
-        title: const Text('Безопасность', style: TextStyle(color: Colors.white)),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-              'Для просмотра фразы восстановления введите TOTP код из приложения.',
-              style: TextStyle(color: Colors.grey, fontSize: 13),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: totpController,
-              autofocus: true,
-              keyboardType: TextInputType.number,
-              style: const TextStyle(color: Colors.white),
-              decoration: const InputDecoration(
-                hintText: 'TOTP Код',
-                hintStyle: TextStyle(color: Colors.grey),
+    try {
+      final String? otp = await showDialog<String>(
+        context: context,
+        builder: (context) => AlertDialog(
+          backgroundColor: AppColors.input,
+          title: const Text('Безопасность', style: TextStyle(color: Colors.white)),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'Для просмотра фразы восстановления введите TOTP код из приложения.',
+                style: TextStyle(color: Colors.grey, fontSize: 13),
               ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: totpController,
+                autofocus: true,
+                keyboardType: TextInputType.number,
+                style: const TextStyle(color: Colors.white),
+                decoration: const InputDecoration(
+                  hintText: 'TOTP Код',
+                  hintStyle: TextStyle(color: Colors.grey),
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(context), child: const Text('Отмена')),
+            TextButton(
+              onPressed: () => Navigator.pop(context, totpController.text.trim()),
+              child: const Text('Подтвердить'),
             ),
           ],
         ),
-        actions: [
-          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Отмена')),
-          TextButton(
-            onPressed: () => Navigator.pop(context, totpController.text),
-            child: const Text('Подтвердить'),
-          ),
-        ],
-      ),
-    );
+      );
 
-    if (otp == null || otp.isEmpty) return;
+      if (otp == null || otp.isEmpty) return;
 
-    setState(() => _isProfileLoading = true);
-    try {
-      // 2. Verify TOTP to get short-lived seed_access_token
+      setState(() => _isProfileLoading = true);
+
       final verifyResponse = await ApiService.post(
         AppConfig.verifyTotpUrl,
         headers: {'X-OTP': otp},
         body: {},
       );
 
-      if (verifyResponse.statusCode == 200) {
-        final verifyData = json.decode(verifyResponse.body);
-        final String accessToken = verifyData['seed_access_token'];
-
-        // 3. Fetch seed phrase using the token
-        final seedResponse = await http.get(
-          Uri.parse(AppConfig.seedPhraseUrl),
-          headers: {'Authorization': 'Bearer $accessToken'},
-        );
-
-        if (seedResponse.statusCode == 200) {
-          final seedData = json.decode(seedResponse.body);
-          final String seedPhrase = seedData['seed_phrase'];
-
-          if (!mounted) return;
-          _showSeedPhraseDialog(seedPhrase);
-        } else {
-          _showError('Ошибка загрузки фразы');
-        }
-      } else {
+      if (verifyResponse.statusCode != 200) {
         _showError('Неверный TOTP код');
+        return;
       }
+
+      final verifyData = json.decode(verifyResponse.body) as Map<String, dynamic>;
+      final accessToken = verifyData['seed_access_token'] as String?;
+      if (accessToken == null || accessToken.isEmpty) {
+        _showError('Не удалось подтвердить доступ');
+        return;
+      }
+
+      final seedResponse = await http.get(
+        Uri.parse(AppConfig.seedPhraseUrl),
+        headers: {'Authorization': 'Bearer $accessToken'},
+      );
+
+      if (seedResponse.statusCode != 200) {
+        _showError('Ошибка загрузки фразы');
+        return;
+      }
+
+      final seedData = json.decode(seedResponse.body) as Map<String, dynamic>;
+      final encryptedPhrase = seedData['seed_phrase_encrypted'] as String?;
+      final legacyPhrase = seedData['seed_phrase'] as String?;
+      if ((encryptedPhrase == null || encryptedPhrase.isEmpty) &&
+          (legacyPhrase == null || legacyPhrase.isEmpty)) {
+        _showError('Фраза восстановления не настроена');
+        return;
+      }
+
+      String phrase;
+      SecureBuffer? seedBuffer;
+      if (encryptedPhrase != null && encryptedPhrase.isNotEmpty) {
+        seedBuffer = await VaultService().decryptAccountSeedPhraseSecure(encryptedPhrase);
+        final phraseBytes = seedBuffer.getBytesCopy();
+        phrase = String.fromCharCodes(phraseBytes);
+        phraseBytes.fillRange(0, phraseBytes.length, 0);
+      } else {
+        phrase = legacyPhrase!;
+      }
+
+      if (!mounted) return;
+      await _showSeedPhraseDialog(phrase);
+      await nativeWipe(phrase);
+      seedBuffer?.wipe();
     } catch (e) {
       _showError('Ошибка соединения: $e');
     } finally {
-      setState(() => _isProfileLoading = false);
+      await wipeController(totpController);
+      totpController.dispose();
+      if (mounted) {
+        setState(() => _isProfileLoading = false);
+      }
     }
   }
 
@@ -1764,21 +1793,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     if (confirmed != true) return;
 
-    // BIP-39 Mock for demonstration (Actual implementation should use a library)
-    final List<String> words = [
-      'abandon', 'ability', 'able', 'about', 'above', 'absent', 'absorb', 'abstract', 
-      'absurd', 'abuse', 'access', 'accident', 'account', 'accuse', 'achieve', 'acid', 
-      'acoustic', 'acquire', 'across', 'act', 'action', 'actor', 'actress', 'actual'
-    ];
-    final random = DateTime.now().millisecondsSinceEpoch;
-    final List<String> seed = List.generate(12, (i) => words[(random + i * i) % words.length]);
-    final String phrase = seed.join(' ');
+    final String phrase = bip39.generateMnemonic(strength: 128);
+    final encryptedPhrase = await VaultService().encryptAccountSeedPhrase(phrase);
 
     setState(() => _isProfileLoading = true);
     try {
       final response = await ApiService.post(
         AppConfig.seedPhraseUrl,
-        body: {'seed_phrase': phrase},
+        body: {'seed_phrase_encrypted': encryptedPhrase},
       );
 
       if (response.statusCode == 200) {
@@ -1786,7 +1808,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           _hasSeedPhrase = true;
         });
         if (!mounted) return;
-        _showSeedPhraseDialog(phrase);
+        await _showSeedPhraseDialog(phrase);
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(backgroundColor: Colors.green, content: Text('Фраза восстановления успешно создана')),
         );
@@ -1796,12 +1818,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
     } catch (e) {
       _showError('Ошибка соединения: $e');
     } finally {
-      setState(() => _isProfileLoading = false);
+      await nativeWipe(phrase);
+      if (mounted) {
+        setState(() => _isProfileLoading = false);
+      }
     }
   }
 
-  void _showSeedPhraseDialog(String phrase) {
-    showDialog(
+  Future<void> _showSeedPhraseDialog(String phrase) {
+    return showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         backgroundColor: AppColors.input,
@@ -1840,8 +1865,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
             child: const Text('Закрыть'),
           ),
           ElevatedButton(
-            onPressed: () {
-              Clipboard.setData(ClipboardData(text: phrase));
+            onPressed: () async {
+              await copyWithAutoClear(phrase);
+              if (!mounted) return;
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(content: Text('Фраза скопирована в буфер обмена')),
               );

--- a/lib/screens/setup_pin_screen.dart
+++ b/lib/screens/setup_pin_screen.dart
@@ -343,22 +343,12 @@ class _SetupPinScreenState extends State<SetupPinScreen>
                   const SizedBox(height: 20),
 
                   if (!_isConfirming)
-                    TextButton(
-                      onPressed: () async {
-                        // Persist master key using device keystore so user can
-                        // re-enter the app without PIN on cold restart.
-                        await VaultService().storeNoPinMasterKey();
-                        if (mounted) {
-                          Navigator.pushNamedAndRemoveUntil(
-                            context,
-                            '/passwords',
-                            (route) => false,
-                          );
-                        }
-                      },
-                      child: const Text(
-                        'Пропустить',
-                        style: TextStyle(color: Colors.grey, fontSize: 16),
+                    const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 8),
+                      child: Text(
+                        'PIN обязателен: мастер-ключ больше не сохраняется без локального секрета.',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(color: Colors.grey, fontSize: 14),
                       ),
                     ),
                 ],

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
@@ -8,6 +7,7 @@ import 'package:form_builder_validators/form_builder_validators.dart';
 import '../theme/colors.dart';
 import '../config/app_config.dart';
 import '../widgets/two_factor_setup_dialog.dart';
+import '../services/auth_token_storage.dart';
 import '../services/vault_service.dart';
 import '../models/server_error.dart';
 import '../utils/form_error_handler.dart';
@@ -154,8 +154,7 @@ class _SignUpScreenState extends State<SignUpScreen> with SingleTickerProviderSt
           // 3. Save Master Key to session (VaultService) after successful 2FA setup
           await VaultService.saveMasterKey(masterKey);
 
-          final prefs = await SharedPreferences.getInstance();
-          await prefs.setString('token', setupData['access_token']);
+          await AuthTokenStorage.writeAccessToken(setupData['access_token'] as String);
 
           if (!mounted) return;
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:safe_device/safe_device.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:nk3_zero/screens/login_screen.dart';
@@ -12,6 +11,7 @@ import 'package:nk3_zero/screens/setup_pin_screen.dart';
 import '../config/app_config.dart';
 import '../utils/pin_security.dart';
 import '../utils/biometric_service.dart';
+import '../services/auth_token_storage.dart';
 import '../services/vault_service.dart';
 
 class SplashScreen extends StatefulWidget {
@@ -58,8 +58,7 @@ class _SplashScreenState extends State<SplashScreen> {
   }
 
   Future<void> _navigateNext() async {
-    final prefs = await SharedPreferences.getInstance();
-    final token = prefs.getString('token');
+    final token = await AuthTokenStorage.readAccessToken();
     final hasPinHash = await PinSecurity.hasPinHash();
 
     if (!mounted) return;
@@ -75,7 +74,8 @@ class _SplashScreenState extends State<SplashScreen> {
         // User has a PIN → go to PIN screen to unlock vault.
         destination = const PinScreen();
       } else {
-        // No PIN set — check biometric first, then fall back to no-PIN key.
+        // No PIN set — require biometric unlock. We no longer keep a no-PIN
+        // master-key copy on disk because that weakens the E2E/local secrecy model.
         final biometricEnabled = await BiometricService.isBiometricEnabled();
         if (biometricEnabled) {
           final secretB64 = await BiometricService.authenticate(
@@ -85,14 +85,10 @@ class _SplashScreenState extends State<SplashScreen> {
             VaultService().setKey(SecretKey(base64.decode(secretB64)));
             destination = const PasswordsScreen();
           } else {
-            // Biometric failed/cancelled — try no-PIN key or require login.
-            final restored = await VaultService().loadNoPinMasterKey();
-            destination = restored ? const PasswordsScreen() : const LoginScreen();
+            destination = const LoginScreen();
           }
         } else {
-          // Biometric not enabled — try no-PIN stored key.
-          final restored = await VaultService().loadNoPinMasterKey();
-          destination = restored ? const PasswordsScreen() : const LoginScreen();
+          destination = const LoginScreen();
         }
       }
     } else {

--- a/lib/screens/telegram_binding_screen.dart
+++ b/lib/screens/telegram_binding_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../theme/colors.dart';
 import '../widgets/themed_widgets.dart';
 import '../config/app_config.dart';
+import '../services/auth_token_storage.dart';
 import '../utils/api_service.dart';
 import '../widgets/otp_input_dialog.dart';
 
@@ -29,8 +29,11 @@ class _TelegramBindingScreenState extends State<TelegramBindingScreen> {
   Future<void> _loadProfile() async {
     setState(() => _isLoading = true);
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final token = prefs.getString('token');
+      final token = await AuthTokenStorage.readAccessToken();
+      if (token == null || token.isEmpty) {
+        setState(() => _errorMessage = 'Сессия истекла, войдите снова');
+        return;
+      }
 
       final response = await ApiService.get(
         AppConfig.profileUrl,
@@ -74,8 +77,11 @@ class _TelegramBindingScreenState extends State<TelegramBindingScreen> {
     });
 
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final token = prefs.getString('token');
+      final token = await AuthTokenStorage.readAccessToken();
+      if (token == null || token.isEmpty) {
+        setState(() => _errorMessage = 'Сессия истекла, войдите снова');
+        return;
+      }
 
       final response = await ApiService.post(
         '${AppConfig.baseUrl}/profile/update',

--- a/lib/services/auth_token_storage.dart
+++ b/lib/services/auth_token_storage.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AuthTokenStorage {
+  AuthTokenStorage._();
+
+  static const _tokenKey = 'token';
+  static const FlutterSecureStorage _secureStorage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+  );
+
+  static Future<String?> readAccessToken() async {
+    final secureToken = await _secureStorage.read(key: _tokenKey);
+    if (secureToken != null && secureToken.isNotEmpty) {
+      return secureToken;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final legacyToken = prefs.getString(_tokenKey);
+    if (legacyToken == null || legacyToken.isEmpty) {
+      return null;
+    }
+
+    await _secureStorage.write(key: _tokenKey, value: legacyToken);
+    await prefs.remove(_tokenKey);
+    return legacyToken;
+  }
+
+  static Future<void> writeAccessToken(String token) async {
+    await _secureStorage.write(key: _tokenKey, value: token);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_tokenKey);
+  }
+
+  static Future<void> clearAccessToken() async {
+    await _secureStorage.delete(key: _tokenKey);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_tokenKey);
+  }
+}

--- a/lib/services/crypto_service.dart
+++ b/lib/services/crypto_service.dart
@@ -68,7 +68,7 @@ class CryptoService {
   }
 
   /// Decrypts data from base64(nonce + ciphertext + tag).
-  Future<String> decrypt(SecretKey key, String encryptedB64) async {
+  Future<Uint8List> decryptToBytes(SecretKey key, String encryptedB64) async {
     final data = base64.decode(encryptedB64);
 
     // AesGcm uses 12-byte nonce and 16-byte MAC (tag)
@@ -86,8 +86,17 @@ class CryptoService {
     final secretBox = SecretBox(ciphertext, nonce: nonce, mac: Mac(macBytes));
 
     final clearText = await _aesGcm.decrypt(secretBox, secretKey: key);
+    return Uint8List.fromList(clearText);
+  }
 
-    return utf8.decode(clearText);
+  /// Decrypts data from base64(nonce + ciphertext + tag).
+  Future<String> decrypt(SecretKey key, String encryptedB64) async {
+    final clearText = await decryptToBytes(key, encryptedB64);
+    try {
+      return utf8.decode(clearText);
+    } finally {
+      clearText.fillRange(0, clearText.length, 0);
+    }
   }
 
   /// Helper for encrypting a full metadata object (site_url, site_login, etc.)

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../utils/api_service.dart';
 import '../utils/biometric_service.dart';
 import '../utils/memory_security.dart';
+import 'auth_token_storage.dart';
 import 'crypto_service.dart';
 import 'cache_service.dart';
 import '../config/app_config.dart';
@@ -75,6 +76,24 @@ class VaultService {
       return true;
     }
     return false;
+  }
+
+  Map<String, dynamic> _buildEncryptedMetadata({
+    required String name,
+    required String url,
+    required String login,
+    String? seedPhrase,
+  }) {
+    final metadata = <String, dynamic>{
+      'site_url': url,
+      'site_login': login,
+      'name': name,
+    };
+    final trimmedSeed = seedPhrase?.trim();
+    if (trimmedSeed != null && trimmedSeed.isNotEmpty) {
+      metadata['seed_phrase'] = trimmedSeed;
+    }
+    return metadata;
   }
 
   Future<void> storeMasterKeyWithPin(String pin) async {
@@ -165,45 +184,15 @@ class VaultService {
     }
   }
 
-  // ── No-PIN master key storage (device-keystore backed, no user secret) ───────
-  // Used when the user opts out of PIN — the master key is still protected by
-  // the Android Keystore / iOS Secure Enclave at the OS level.
-  static const _noPinStorageKey = 'master_key_no_pin';
-
-  /// Persist master key without a user PIN. Only call when the vault is unlocked.
-  Future<void> storeNoPinMasterKey() async {
-    if (_masterKey == null) return;
-    final keyBytes = Uint8List.fromList(await _masterKey!.extractBytes());
-    await _storage.write(key: _noPinStorageKey, value: base64.encode(keyBytes));
-    keyBytes.fillRange(0, keyBytes.length, 0);
-  }
-
-  /// Restore master key from no-PIN storage. Returns true on success.
-  Future<bool> loadNoPinMasterKey() async {
-    final stored = await _storage.read(key: _noPinStorageKey);
-    if (stored == null) return false;
-    try {
-      _masterKey = SecretKey(base64.decode(stored));
-      return true;
-    } catch (_) {
-      return false;
-    }
-  }
-
-  /// Erase no-PIN master key (call after user sets up PIN or logs out).
-  Future<void> clearNoPinMasterKey() async {
-    await _storage.delete(key: _noPinStorageKey);
-  }
-
   Future<void> clearAllData() async {
     lock();
 
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('token');
     await prefs.remove('pin_hash');
     await prefs.remove('pin_code');
     await prefs.remove(_saltKey);
 
+    await AuthTokenStorage.clearAccessToken();
     await _storage.delete(key: _storageKey);
     await _storage.deleteAll();
 
@@ -272,8 +261,12 @@ class VaultService {
   /// **Caller MUST call [SecureBuffer.wipe] when done with the data.**
   Future<SecureBuffer> decryptPayloadSecure(String encryptedB64) async {
     if (_masterKey == null) throw Exception('Vault is locked');
-    final plaintext = await _crypto.decrypt(_masterKey!, encryptedB64);
-    return SecureBuffer.fromBytes(plaintext.codeUnits);
+    final plaintextBytes = await _crypto.decryptToBytes(_masterKey!, encryptedB64);
+    try {
+      return SecureBuffer.fromBytes(plaintextBytes);
+    } finally {
+      plaintextBytes.fillRange(0, plaintextBytes.length, 0);
+    }
   }
 
   /// Decrypts a payload to a plain String (use only for edit/save — not display).
@@ -296,17 +289,26 @@ class VaultService {
     if (_masterKey == null) throw Exception('Vault is locked');
 
     final siteHash      = await _crypto.computeSiteHash(_masterKey!, url);
-    final encMeta       = await _crypto.encryptMetadata(_masterKey!, {'site_url': url, 'site_login': login, 'name': name});
+    final normalizedSeed = seedPhrase?.trim();
+    final hasSeedPhrase = normalizedSeed != null && normalizedSeed.isNotEmpty;
+    final encMeta       = await _crypto.encryptMetadata(
+      _masterKey!,
+      _buildEncryptedMetadata(
+        name: name,
+        url: url,
+        login: login,
+        seedPhrase: normalizedSeed,
+      ),
+    );
     final encPayload    = await _crypto.encrypt(_masterKey!, password);
     final encNotes      = notes       != null ? await _crypto.encrypt(_masterKey!, notes)       : null;
-    final encSeed       = seedPhrase  != null ? await _crypto.encrypt(_masterKey!, seedPhrase)  : null;
 
     final response = await ApiService.post(AppConfig.passwordsUrl, body: {
       'site_hash':              siteHash,
       'encrypted_metadata':     encMeta,
       'encrypted_payload':      encPayload,
       'notes_encrypted':        encNotes,
-      'seed_phrase_encrypted':  encSeed,
+      'has_seed_phrase':        hasSeedPhrase,
       'folder_id':              folderId,
     });
     
@@ -330,17 +332,26 @@ class VaultService {
     if (_masterKey == null) throw Exception('Vault is locked');
 
     final siteHash      = await _crypto.computeSiteHash(_masterKey!, url);
-    final encMeta       = await _crypto.encryptMetadata(_masterKey!, {'site_url': url, 'site_login': login, 'name': name});
+    final normalizedSeed = seedPhrase?.trim();
+    final hasSeedPhrase = normalizedSeed != null && normalizedSeed.isNotEmpty;
+    final encMeta       = await _crypto.encryptMetadata(
+      _masterKey!,
+      _buildEncryptedMetadata(
+        name: name,
+        url: url,
+        login: login,
+        seedPhrase: normalizedSeed,
+      ),
+    );
     final encPayload    = await _crypto.encrypt(_masterKey!, password);
     final encNotes      = notes       != null ? await _crypto.encrypt(_masterKey!, notes)       : null;
-    final encSeed       = seedPhrase  != null ? await _crypto.encrypt(_masterKey!, seedPhrase)  : null;
 
     final response = await ApiService.put('${AppConfig.passwordsUrl}/$id', body: {
       'site_hash':              siteHash,
       'encrypted_metadata':     encMeta,
       'encrypted_payload':      encPayload,
       'notes_encrypted':        encNotes,
-      'seed_phrase_encrypted':  encSeed,
+      'has_seed_phrase':        hasSeedPhrase,
     });
 
     // Wipe transient plaintext strings
@@ -363,7 +374,10 @@ class VaultService {
 
       items.add({
         'site_hash':          await _crypto.computeSiteHash(_masterKey!, url),
-        'encrypted_metadata': await _crypto.encryptMetadata(_masterKey!, {'site_url': url, 'site_login': login, 'name': name}),
+        'encrypted_metadata': await _crypto.encryptMetadata(
+          _masterKey!,
+          _buildEncryptedMetadata(name: name, url: url, login: login),
+        ),
         'encrypted_payload':  await _crypto.encrypt(_masterKey!, pwd),
         'has_2fa':            false,
         'has_seed_phrase':    false,
@@ -395,6 +409,8 @@ class VaultService {
         entry['title']    = meta['name']       ?? meta['site_url'] ?? '';
         entry['subtitle'] = meta['site_login'] ?? '';
         entry['site_url'] = meta['site_url']   ?? '';
+        entry['has_seed_phrase'] = (meta['seed_phrase'] is String) &&
+            (meta['seed_phrase'] as String).trim().isNotEmpty;
       }
     } catch (_) {
       entry['title']    = '(encrypted)';
@@ -403,5 +419,46 @@ class VaultService {
 
     // Never put decrypted payload in the list — keep it encrypted for on-demand use
     return entry;
+  }
+
+  Future<SecureBuffer?> decryptSeedPhraseFromMetadataSecure(
+    String? encryptedMetadata,
+  ) async {
+    if (_masterKey == null) throw Exception('Vault is locked');
+    if (encryptedMetadata == null || encryptedMetadata.isEmpty) return null;
+
+    final meta = await _crypto.decryptMetadata(_masterKey!, encryptedMetadata);
+    final seedPhrase = meta['seed_phrase'];
+    if (seedPhrase is! String || seedPhrase.trim().isEmpty) return null;
+    final bytes = Uint8List.fromList(utf8.encode(seedPhrase));
+    await nativeWipe(seedPhrase);
+    return SecureBuffer.fromBytes(bytes);
+  }
+
+  Future<String?> decryptSeedPhraseFromMetadata(String? encryptedMetadata) async {
+    final buffer = await decryptSeedPhraseFromMetadataSecure(encryptedMetadata);
+    if (buffer == null) return null;
+    final bytes = buffer.getBytesCopy();
+    try {
+      return utf8.decode(bytes);
+    } finally {
+      bytes.fillRange(0, bytes.length, 0);
+      buffer.wipe();
+    }
+  }
+
+  Future<String> encryptAccountSeedPhrase(String phrase) async {
+    if (_masterKey == null) throw Exception('Vault is locked');
+    return _crypto.encrypt(_masterKey!, phrase.trim());
+  }
+
+  Future<SecureBuffer> decryptAccountSeedPhraseSecure(String encryptedB64) async {
+    if (_masterKey == null) throw Exception('Vault is locked');
+    final plaintextBytes = await _crypto.decryptToBytes(_masterKey!, encryptedB64);
+    try {
+      return SecureBuffer.fromBytes(plaintextBytes);
+    } finally {
+      plaintextBytes.fillRange(0, plaintextBytes.length, 0);
+    }
   }
 }

--- a/lib/services/ws_service.dart
+++ b/lib/services/ws_service.dart
@@ -1,9 +1,10 @@
 import 'dart:convert';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/io.dart';
 import '../config/app_config.dart';
 import '../main.dart'; // import navigatorKey
+import 'auth_token_storage.dart';
 
 class WsService {
   static final WsService _instance = WsService._internal();
@@ -37,17 +38,19 @@ class WsService {
   void connect() async {
     if (AppConfig.apiBaseUrl == null) return;
 
-    final prefs = await SharedPreferences.getInstance();
-    final token = prefs.getString('token');
+    final token = await AuthTokenStorage.readAccessToken();
     // If user is not authenticated yet, we cannot connect to device channel
     if (token == null || token.isEmpty) return;
 
     final wsUrl = AppConfig.apiBaseUrl!.replaceFirst('http', 'ws');
-    final uri = Uri.parse('$wsUrl/ws/device-events?token=$token');
+    final uri = Uri.parse('$wsUrl/ws/device-events');
 
     try {
       _channel?.sink.close();
-      _channel = WebSocketChannel.connect(uri);
+      _channel = IOWebSocketChannel.connect(
+        uri,
+        headers: {'Authorization': 'Bearer $token'},
+      );
 
       _channel!.stream.listen(
         (message) {

--- a/lib/utils/api_service.dart
+++ b/lib/utils/api_service.dart
@@ -1,14 +1,13 @@
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../main.dart'; // Для navigatorKey
+import '../services/auth_token_storage.dart';
 import '../widgets/otp_input_dialog.dart';
 
 class ApiService {
   static Future<Map<String, String>> _getHeaders() async {
-    final prefs = await SharedPreferences.getInstance();
-    final token = prefs.getString('token');
+    final token = await AuthTokenStorage.readAccessToken();
     return {
       'Content-Type': 'application/json',
       if (token != null) 'Authorization': 'Bearer $token',

--- a/lib/utils/hidden_folder_service.dart
+++ b/lib/utils/hidden_folder_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:shared_preferences/shared_preferences.dart';
 import '../config/app_config.dart';
+import '../services/auth_token_storage.dart';
 
 /// In-memory session service that tracks whether the user has unlocked
 /// hidden folders via TOTP this session. Resets on app restart.
@@ -16,8 +16,8 @@ class HiddenFolderService {
   /// Submit a TOTP code to the server. Returns true on success.
   Future<bool> verifyTotp(String code) async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final token = prefs.getString('token');
+      final token = await AuthTokenStorage.readAccessToken();
+      if (token == null || token.isEmpty) return false;
 
       final response = await http.post(
         Uri.parse(AppConfig.verifyTotpUrl),

--- a/lib/utils/memory_security.dart
+++ b/lib/utils/memory_security.dart
@@ -1,8 +1,10 @@
+import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:crypto/crypto.dart';
 
 // ── SecureBuffer ──────────────────────────────────────────────────────────────
 
@@ -126,18 +128,20 @@ Future<void> copySecureBuffer(SecureBuffer buffer, {
 }) async {
   final copy = buffer.getBytesCopy();
   final text = String.fromCharCodes(copy);
+  final clipboardHash = sha256.convert(utf8.encode(text)).toString();
   
   try {
     await Clipboard.setData(ClipboardData(text: text));
+    await nativeWipe(text);
     
     // Schedule system clipboard clear
     Future.delayed(clearAfter, () async {
       final current = await Clipboard.getData('text/plain');
-      if (current?.text == text) {
+      final currentText = current?.text;
+      if (currentText != null &&
+          sha256.convert(utf8.encode(currentText)).toString() == clipboardHash) {
         await Clipboard.setData(const ClipboardData(text: ''));
       }
-      // Also notify native to wipe the system's memory of this string
-      await nativeWipe(text);
     });
   } finally {
     copy.fillRange(0, copy.length, 0);
@@ -148,12 +152,15 @@ Future<void> copySecureBuffer(SecureBuffer buffer, {
 Future<void> copyWithAutoClear(String text, {
   Duration clearAfter = const Duration(seconds: 30),
 }) async {
+  final clipboardHash = sha256.convert(utf8.encode(text)).toString();
   await Clipboard.setData(ClipboardData(text: text));
+  await nativeWipe(text);
   Future.delayed(clearAfter, () async {
     final current = await Clipboard.getData('text/plain');
-    if (current?.text == text) {
+    final currentText = current?.text;
+    if (currentText != null &&
+        sha256.convert(utf8.encode(currentText)).toString() == clipboardHash) {
       await Clipboard.setData(const ClipboardData(text: ''));
     }
-    await nativeWipe(text);
   });
 }

--- a/lib/utils/passkey_service.dart
+++ b/lib/utils/passkey_service.dart
@@ -80,7 +80,6 @@ class PasskeyService {
       final verifyData = json.decode(verifyResponse.body);
       return verifyData['status'] == 'success';
     } catch (e) {
-      print('Passkey Registration Error: $e');
       return false;
     }
   }
@@ -140,7 +139,6 @@ class PasskeyService {
       if (verifyResponse.statusCode != 200) return null;
       return json.decode(verifyResponse.body);
     } catch (e) {
-      print('Passkey Login Error: $e');
       return null;
     }
   }

--- a/lib/utils/password_history_service.dart
+++ b/lib/utils/password_history_service.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../config/app_config.dart';
+import '../services/auth_token_storage.dart';
 import '../utils/api_service.dart';
 
 class PasswordHistoryService {
@@ -24,7 +24,6 @@ class PasswordHistoryService {
 
       return response.statusCode == 200 || response.statusCode == 201;
     } catch (e) {
-      print('Ошибка при добавлении записи в историю: $e');
       return false;
     }
   }
@@ -32,8 +31,7 @@ class PasswordHistoryService {
   // Получить историю паролей
   static Future<List<Map<String, dynamic>>> getPasswordHistory() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final token = prefs.getString('token');
+      final token = await AuthTokenStorage.readAccessToken();
 
       if (token == null) {
         return [];
@@ -51,7 +49,6 @@ class PasswordHistoryService {
 
       return [];
     } catch (e) {
-      print('Ошибка при получении истории паролей: $e');
       return [];
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   passkeys: ^2.8.2
   flutter_secure_storage: ^9.0.0
   cryptography: ^2.5.0
+  bip39: ^1.0.6
   hive_flutter: ^1.1.0
   path_provider: ^2.1.2
   flutter_form_builder: ^9.6.0

--- a/server/config.py
+++ b/server/config.py
@@ -32,8 +32,8 @@ class Settings:
     # JWT Settings (MANDATORY: No fallbacks)
     JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY", "")
     ALGORITHM: str = "HS256"  # Locked for security
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", str(60 * 24 * 30)))
-    REFRESH_TOKEN_EXPIRE_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "365"))
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "15"))
+    REFRESH_TOKEN_EXPIRE_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "7"))
     
     # Critical Keys (MANDATORY: No fallbacks)
     SEED_PHRASE_KEY: str = os.getenv("SEED_PHRASE_KEY", "")
@@ -96,8 +96,14 @@ class Settings:
     # For Flutter, the origin is usually the app's package name or a specific URL
     # For local development with a proxy/web, it might be http://localhost:PORT
     EXPECTED_ORIGIN: str = os.getenv("EXPECTED_ORIGIN", "http://localhost")
+    WEBAUTHN_ALLOWED_ORIGINS: list[str] = [
+        x.strip() for x in os.getenv("WEBAUTHN_ALLOWED_ORIGINS", os.getenv("EXPECTED_ORIGIN", "http://localhost")).split(",")
+        if x.strip()
+    ]
     ALLOWED_ORIGINS: list[str] = os.getenv("ALLOWED_ORIGINS", "*").split(",")
     _whitelist: str = os.getenv("WHITELIST_IPS", "127.0.0.1,::1")
     WHITELIST_IPS: list[str] = [x.strip() for x in _whitelist.split(",") if x.strip()]
+    _trusted_proxies: str = os.getenv("TRUSTED_PROXY_RANGES", "127.0.0.1,::1")
+    TRUSTED_PROXY_RANGES: list[str] = [x.strip() for x in _trusted_proxies.split(",") if x.strip()]
 
 settings = Settings()

--- a/server/main.py
+++ b/server/main.py
@@ -40,7 +40,7 @@ from .auth.service import verify_hardened_otp
 from .config import settings
 from .database import engine, get_db
 import logging
-from .utils import get_favicon_url, get_client_ip, EncryptionService
+from .utils import get_favicon_url, EncryptionService
 from .auth.dependencies import get_current_user, get_seed_access_user
 from .middleware import SecurityMiddleware, ProxyHeadersMiddleware
 
@@ -161,8 +161,13 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 @app.websocket("/ws/device-events")
-async def websocket_device_events(websocket: WebSocket, token: str):
+async def websocket_device_events(websocket: WebSocket, token: Optional[str] = None):
     try:
+        auth_header = websocket.headers.get("authorization")
+        if (token is None or not token) and auth_header and auth_header.lower().startswith("bearer "):
+            token = auth_header.split(" ", 1)[1].strip()
+        if not token:
+            raise ValueError("Missing token")
         payload = auth_service.decode_token(token)
         user_id = int(payload.get("sub"))
     except Exception:
@@ -226,21 +231,23 @@ def get_seed_phrase(
     current_user: models.User = Depends(get_seed_access_user),
     db: Session = Depends(get_db)
 ):
-    """Retrieve the encrypted seed phrase. Requires specialized short-lived token."""
+    """Retrieve the client-encrypted seed phrase blob. Requires short-lived token."""
     if not current_user.seed_phrase_encrypted:
         raise HTTPException(status_code=404, detail="Seed phrase not set")
 
     # Access Log
     crud.audit_event(db, current_user.id, "seed_phrase_viewed")
     
-    # Decrypt with Server Key and return
-    decrypted = EncryptionService.decrypt(current_user.seed_phrase_encrypted)
-    
     # Update last viewed
     current_user.seed_phrase_last_viewed_at = datetime.now(timezone.utc)
     db.commit()
     
-    return {"seed_phrase": decrypted}
+    stored_value = current_user.seed_phrase_encrypted
+    if stored_value.startswith("client:"):
+        return {"seed_phrase_encrypted": stored_value.removeprefix("client:")}
+
+    legacy_plaintext = EncryptionService.decrypt(stored_value)
+    return {"seed_phrase": legacy_plaintext}
 
 
 @app.post("/profile/seed-phrase")
@@ -252,8 +259,9 @@ def set_seed_phrase(
     db: Session = Depends(get_db)
 ):
     """Set or rotate the seed phrase. Rotation requires multi-factor proof."""
+    encrypted_phrase = body.get("seed_phrase_encrypted")
     new_phrase = body.get("seed_phrase")
-    if not new_phrase:
+    if not encrypted_phrase and not new_phrase:
         raise HTTPException(status_code=400, detail="Seed phrase required")
 
     # If it's a rotation, we should ideally verify old phrase or password
@@ -263,28 +271,14 @@ def set_seed_phrase(
         verify_hardened_otp(db, current_user, otp)
 
     # Encrypt with Server Key
-    current_user.seed_phrase_encrypted = EncryptionService.encrypt(new_phrase)
+    if encrypted_phrase:
+        current_user.seed_phrase_encrypted = f"client:{encrypted_phrase}"
+    else:
+        current_user.seed_phrase_encrypted = EncryptionService.encrypt(new_phrase)
     db.commit()
     
     crud.audit_event(db, current_user.id, "seed_phrase_updated")
     return {"success": True}
-
-
-@app.post("/refresh")
-@limiter.limit("5/minute")
-def refresh_token(request: Request, payload: dict, background_tasks: BackgroundTasks, db: Session = Depends(get_db)):
-    token = payload.get("refresh_token")
-    if not token:
-        crud.audit_event(db, None, "refresh_token_failed", {"reason": "token_missing"}, ip=request.client.host, background_tasks=background_tasks)
-        raise HTTPException(status_code=400, detail="Refresh token missing")
-
-    try:
-        new_access, new_refresh = auth_service.rotate_refresh_token(db, token)
-        crud.audit_event(db, None, "token_refreshed", ip=request.client.host, background_tasks=background_tasks)
-        return {"access_token": new_access, "refresh_token": new_refresh, "token_type": "bearer"}
-    except Exception as e:
-        crud.audit_event(db, None, "refresh_token_failed", {"reason": str(e)}, ip=request.client.host, background_tasks=background_tasks)
-        raise HTTPException(status_code=401, detail="Invalid refresh token")
 
 
 @app.get("/passwords", response_model=List[schemas.PasswordResponse])
@@ -595,6 +589,19 @@ def confirm_backend_change(
 
 # ── WebAuthn Endpoints ────────────────────────────────────────────────────────
 
+def _get_webauthn_rp_id() -> str:
+    return settings.RP_ID
+
+
+def _get_webauthn_origin(request: Request) -> str:
+    origin = request.headers.get("origin")
+    if not origin:
+        return settings.EXPECTED_ORIGIN
+    if origin not in settings.WEBAUTHN_ALLOWED_ORIGINS:
+        raise HTTPException(status_code=400, detail="Invalid origin")
+    return origin
+
+
 @app.post("/webauthn/register/options")
 @limiter.limit("5/minute")
 async def webauthn_register_options(
@@ -603,8 +610,7 @@ async def webauthn_register_options(
     current_user: models.User = Depends(auth_deps.get_current_user),
     db: Session = Depends(get_db)
 ):
-    host = request.headers.get("host", "localhost")
-    rp_id = host.split(":")[0]
+    rp_id = _get_webauthn_rp_id()
 
     options = generate_registration_options(
         rp_id=rp_id,
@@ -634,9 +640,8 @@ async def webauthn_register_verify(
     current_user: models.User = Depends(auth_deps.get_current_user),
     db: Session = Depends(get_db)
 ):
-    host = request.headers.get("host", "localhost")
-    rp_id = host.split(":")[0]
-    expected_origin = request.headers.get("origin", settings.EXPECTED_ORIGIN)
+    rp_id = _get_webauthn_rp_id()
+    expected_origin = _get_webauthn_origin(request)
 
     challenge_data = crud.get_challenge(db, verify_data.registration_response.get("challenge"))
     if not challenge_data or challenge_data.type != "registration":
@@ -688,8 +693,7 @@ async def webauthn_login_options(
     request: Request,
     db: Session = Depends(get_db)
 ):
-    host = request.headers.get("host", "localhost")
-    rp_id = host.split(":")[0]
+    rp_id = _get_webauthn_rp_id()
 
     options = generate_authentication_options(
         rp_id=rp_id,
@@ -712,9 +716,8 @@ async def webauthn_login_verify(
     verify_data: schemas.WebAuthnLoginVerify,
     db: Session = Depends(get_db)
 ):
-    host = request.headers.get("host", "localhost")
-    rp_id = host.split(":")[0]
-    expected_origin = request.headers.get("origin", settings.EXPECTED_ORIGIN)
+    rp_id = _get_webauthn_rp_id()
+    expected_origin = _get_webauthn_origin(request)
 
     common_error = HTTPException(status_code=400, detail="Authentication failed")
 

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -1,12 +1,13 @@
 import logging
+import ipaddress
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 from sqlalchemy.orm import Session
 from datetime import timedelta
 
 from .database import SessionLocal
+from .config import settings
 from .security import SecurityManager
-from .utils import get_client_ip
 
 logger = logging.getLogger("zero_vault.security")
 
@@ -60,10 +61,6 @@ class ProxyHeadersMiddleware(BaseHTTPMiddleware):
     Prevents IP spoofing by validating X-Forwarded-For headers.
     """
     async def dispatch(self, request: Request, call_next):
-        # List of trusted proxies (e.g., local nginx, docker network, or Cloudflare IPs)
-        # In a real production environment, this should be moved to settings.
-        trusted_proxies = {"127.0.0.1", "::1", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
-        
         forwarded_for = request.headers.get("x-forwarded-for")
         if forwarded_for:
             # The client IP is the first entry in X-Forwarded-For
@@ -72,10 +69,30 @@ class ProxyHeadersMiddleware(BaseHTTPMiddleware):
             # Verify if the immediate requester IP is a trusted proxy
             # If request.client is None (e.g. test client), we might skip or assume trusted in dev
             requester_ip = request.client.host if request.client else "127.0.0.1"
-            
-            if requester_ip in trusted_proxies:
-                # Rewrite the client in scope so request.client.host returns the real client IP
-                request.scope["client"] = (client_ip, request.client.port if request.client else 0)
+            trusted = False
+            try:
+                requester_addr = ipaddress.ip_address(requester_ip)
+                for entry in settings.TRUSTED_PROXY_RANGES:
+                    try:
+                        if "/" in entry:
+                            if requester_addr in ipaddress.ip_network(entry, strict=False):
+                                trusted = True
+                                break
+                        elif requester_ip == entry:
+                            trusted = True
+                            break
+                    except ValueError:
+                        continue
+            except ValueError:
+                trusted = False
+
+            if trusted:
+                try:
+                    ipaddress.ip_address(client_ip)
+                    # Rewrite the client in scope so request.client.host returns the real client IP
+                    request.scope["client"] = (client_ip, request.client.port if request.client else 0)
+                except ValueError:
+                    logger.warning("Invalid X-Forwarded-For client IP from trusted proxy: %s", client_ip)
             else:
                 logger.warning(f"Untrusted proxy header detected from {requester_ip}. Header ignored.")
                 

--- a/server/security.py
+++ b/server/security.py
@@ -328,13 +328,18 @@ class SecurityManager:
 
     @staticmethod
     def is_ip_whitelisted(ip: str) -> bool:
-        if ip in settings.WHITELIST_IPS:
-            return True
-            
         try:
             addr = ipaddress.ip_address(ip)
-            # Allow private network (192.168.x.x, 10.x.x.x, etc), loopback, and link-local
-            return addr.is_private or addr.is_loopback or addr.is_link_local
+            for entry in settings.WHITELIST_IPS:
+                try:
+                    if "/" in entry:
+                        if addr in ipaddress.ip_network(entry, strict=False):
+                            return True
+                    elif ip == entry:
+                        return True
+                except ValueError:
+                    continue
+            return False
         except ValueError:
             return False
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -102,16 +102,14 @@ class TestLogin:
     def test_wrong_password_does_not_return_tokens(self, client):
         _register(client)
         r = _login(client, password="WrongPass!12345#Z")
-        assert r.status_code == 200
-        data = r.json()
-        assert not data.get("access_token")
+        assert r.status_code == 401
+        assert "access_token" not in r.text
 
     def test_nonexistent_user_does_not_leak_existence(self, client):
         r = _login(client, login="ghost")
         # Must not 500 and must not reveal "user not found"
-        assert r.status_code == 200
-        data = r.json()
-        assert not data.get("access_token")
+        assert r.status_code == 401
+        assert "user not found" not in r.text.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/server/tests/test_security_hardening.py
+++ b/server/tests/test_security_hardening.py
@@ -1,0 +1,50 @@
+from starlette.requests import Request
+
+from server.main import _get_webauthn_origin, app
+from server.utils import get_client_ip
+
+
+def _make_request(*, client_host: str, headers: list[tuple[bytes, bytes]] | None = None) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": headers or [],
+        "client": (client_host, 12345),
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+def test_get_client_ip_ignores_untrusted_x_forwarded_for():
+    request = _make_request(
+        client_host="203.0.113.10",
+        headers=[(b"x-forwarded-for", b"198.51.100.22")],
+    )
+    assert get_client_ip(request) == "203.0.113.10"
+
+
+def test_get_client_ip_uses_trusted_proxy_x_forwarded_for():
+    request = _make_request(
+        client_host="127.0.0.1",
+        headers=[(b"x-forwarded-for", b"198.51.100.22, 127.0.0.1")],
+    )
+    assert get_client_ip(request) == "198.51.100.22"
+
+
+def test_refresh_route_registered_once():
+    refresh_routes = [
+        route for route in app.routes
+        if getattr(route, "path", None) == "/refresh" and "POST" in getattr(route, "methods", set())
+    ]
+    assert len(refresh_routes) == 1
+
+
+def test_webauthn_origin_allows_configured_origin():
+    request = _make_request(
+        client_host="127.0.0.1",
+        headers=[(b"origin", b"http://localhost")],
+    )
+    assert _get_webauthn_origin(request) == "http://localhost"

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,6 +1,7 @@
 import base64
 import os
 import urllib.parse
+import ipaddress
 from typing import Optional
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -44,11 +45,36 @@ class EncryptionService:
 
 
 def get_client_ip(request: Request) -> str:
-    """Return the real client IP, respecting X-Forwarded-For from trusted proxies."""
+    """Return the real client IP, trusting X-Forwarded-For only from trusted proxies."""
+    requester_ip = request.client.host if request.client else None
+    if requester_ip:
+        try:
+            requester_addr = ipaddress.ip_address(requester_ip)
+            for entry in settings.TRUSTED_PROXY_RANGES:
+                try:
+                    if "/" in entry:
+                        if requester_addr in ipaddress.ip_network(entry, strict=False):
+                            break
+                    elif requester_ip == entry:
+                        break
+                except ValueError:
+                    continue
+            else:
+                return requester_ip
+        except ValueError:
+            return requester_ip
+
     forwarded = request.headers.get("X-Forwarded-For")
     if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+        for hop in forwarded.split(","):
+            candidate = hop.strip()
+            try:
+                ipaddress.ip_address(candidate)
+                return candidate
+            except ValueError:
+                continue
+
+    return requester_ip or "unknown"
 
 
 def get_favicon_url(site_url: Optional[str]) -> Optional[str]:


### PR DESCRIPTION
### Motivation
- Move access tokens out of legacy SharedPreferences into platform-backed secure storage and migrate app code to use it for improved confidentiality.
- Reduce plaintext seed-phrase exposure by moving seed data into encrypted metadata and providing secure, on-demand decryption paths.
- Improve memory hygiene (SecureBuffer, clipboard wiping, native wipe calls) and prevent screenshot leakage on Android.
- Harden server-side origin/proxy handling and WebAuthn/WS authentication semantics to support client-provided encrypted seed blobs and trusted-proxy validation.

### Description
- Added `AuthTokenStorage` using `flutter_secure_storage` with transparent migration from legacy `SharedPreferences`, and replaced direct `SharedPreferences` token reads/writes across the app (`login`, `signup`, `splash`, `passwords`, `settings`, `telegram_binding`, `ws_service`, `api_service`, `password_history_service`, etc.).
- Reworked vault/metadata model: metadata is now stored in `encrypted_metadata` (includes optional `seed_phrase`), `VaultService` builds encrypted metadata, and added secure helpers `decryptSeedPhraseFromMetadataSecure` / `decryptSeedPhraseFromMetadata` and `encryptAccountSeedPhrase`; `addPassword`/`updatePassword`/`importPasswordsBatch` updated accordingly.
- Memory-security improvements: introduced/expanded `SecureBuffer` usage and safer decrypt-to-bytes in `CryptoService`, added `nativeWipe` usage, strengthened clipboard auto-clear with SHA-256 checks to avoid accidental clearing of unrelated clipboard content, and added secure copy helpers (`copySecureBuffer`, `copyWithAutoClear`).
- UI and UX changes to support lazy, secure reveal and wiping: `PasswordDetailScreen`, `EditPasswordScreen`, `AddPasswordScreen`, `PasswordsScreen` updated to use encrypted metadata and secure decryption on demand; seed reveal/copy flows now use secure buffers and native wipe calls.
- Android: set `WindowManager.LayoutParams.FLAG_SECURE` in `MainActivity` to prevent screenshots when app is visible.
- WebSocket: `WsService` now connects using `IOWebSocketChannel` with `Authorization: Bearer` header, and server `/ws/device-events` endpoint accepts token from `authorization` header (or query param for backward compatibility).
- API helpers: `ApiService._getHeaders` now uses `AuthTokenStorage`; `HiddenFolderService` and other utils switched to `AuthTokenStorage`.
- Server-side: tightened defaults for token expiry, added `WEBAUTHN_ALLOWED_ORIGINS` and `TRUSTED_PROXY_RANGES` config, improved WebAuthn origin and rp_id resolution and validation, accept client-encrypted seed blobs (prefix `client:`) for seed-phrase endpoints, added trusted-proxy-aware header handling (`ProxyHeadersMiddleware`) and improved IP/trust checks in `utils.get_client_ip` and `security` utilities.
- Misc: added `bip39` dependency and used it for seed generation in `SettingsScreen`, updated `CryptoService` to expose byte-level decryption, removed legacy no-PIN master-key storage paths and related code, and cleaned some logging/prints in passkey flows.
- Tests: updated server tests to match hardened behavior and added `server/tests/test_security_hardening.py`.

### Testing
- Ran the server test suite (`pytest`) including the new `test_security_hardening.py` and updated auth tests; all tests passed.
- Verified server unit tests that exercise WebAuthn origin checks, seed-phrase APIs, and websocket token handling passed after changes.

------