### PR TITLE
security: close key-escrow, AAD-binding, and KDF-downgrade gaps

### DIFF
--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -1,7 +1,9 @@
 # Security Audit — Zero Password Manager
 
-**Date:** 2026-04-28
-**Scope:** Full DevSec review against the KeePass + Bitwarden red-team checklist,
+**Date:** 2026-04-28 (v1) / 2026-04-28 (v2 addendum)
+**v2 scope:** Backend / E2E / Argon2 architectural review against the 2026
+ETH Zurich + academic Argon2 research checklist. See § "Round 2" below.
+**v1 scope:** Full DevSec review against the KeePass + Bitwarden red-team checklist,
 with mitigation of every CVE-class issue surfaced and a sweep of the
 crypto stack for OWASP 2023+ compliance.
 **Branch:** `claude/password-manager-security-checklist-8EMX6`
@@ -261,4 +263,197 @@ server/auth/service.py                FAKE_ARGON2_HASH (params-matched), removed
                                       generate_derived_key, fixed password-strength substring check
 server/auth/constants.py              Argon2 m=128MB, t=4, p=2 (single source of truth)
 docs/SECURITY_AUDIT.md                this report
+```
+
+---
+
+# Round 2 — Backend / E2E / Architectural
+
+This pass focuses on the threats the OWASP cheat-sheet doesn't cover:
+**malicious-backend** model, **recovery bypass**, **cryptographic binding**,
+and **downgrade**. Three new findings, all fixed.
+
+| #   | Finding                                                                | Severity | Status |
+|-----|------------------------------------------------------------------------|----------|--------|
+| R1  | Server-side seed-phrase encryption (key escrow / recovery bypass)      | CRITICAL | FIXED  |
+| R2  | AES-GCM AAD constant — vault entries swappable by malicious backend    | HIGH     | FIXED  |
+| R3  | Client trusted server-supplied `kdf_iterations` with no floor          | MEDIUM   | FIXED  |
+
+---
+
+## R1 — Server-side seed-phrase encryption (key escrow)
+
+**Files:** `server/main.py`, `server/utils.py`
+
+The `/profile/seed-phrase` SET endpoint accepted **two** body shapes:
+
+```json
+{ "seed_phrase_encrypted": "<client AES-GCM blob>" }   // zero-knowledge path
+{ "seed_phrase":           "<plaintext mnemonic>"  }   // server-encrypts path
+```
+
+The plaintext path called `EncryptionService.encrypt(plaintext)` in
+`server/utils.py`, which used the server-resident `SEED_PHRASE_KEY` env var
+to wrap the blob with AES-GCM and store it. **This is the textbook
+key-escrow / recovery-bypass anti-pattern** highlighted by the 2026
+research: a single backend compromise (DB dump + the env file from the
+same host) decrypts every user's seed phrase and unlocks every vault via
+the seed-phrase recovery flow — without ever touching the master password.
+
+The corresponding GET endpoint compounded the problem by reading
+`current_user.seed_phrase_encrypted`, server-decrypting any non-`client:`
+prefix value, and returning **the plaintext** to the client over HTTPS,
+turning the database into a plaintext oracle for any privileged caller.
+
+**Fix:**
+
+* Plaintext path is rejected outright — any request with a
+  `seed_phrase` field but no `seed_phrase_encrypted` returns
+  `400 plaintext_seed_phrase_disallowed` and emits a
+  `seed_phrase_plaintext_rejected` audit event.
+* Legacy stored blobs (no `client:` prefix) are no longer decrypted on
+  read. The GET endpoint returns
+  `409 legacy_seed_phrase_format` and instructs the client to
+  re-enrol. No path through the API can leak a server-decrypted seed
+  phrase any more.
+* `EncryptionService` is removed from `server/utils.py` along with its
+  import in `main.py`. The class is preserved as a comment-only marker
+  explaining why it intentionally does not exist.
+
+**Note:** the `SEED_PHRASE_KEY` env var is retained because legacy DB rows
+written before this migration may still exist; they are now permanently
+unreadable through the API and should be wiped or re-enrolled.
+
+---
+
+## R2 — AAD binding flaw (malicious-backend record swap)
+
+**Files:** `lib/services/crypto_service.dart`, `lib/services/vault_service.dart`,
+`lib/screens/password_detail_screen.dart`,
+`lib/screens/edit_password_screen.dart`,
+`lib/screens/passwords_screen.dart`
+
+Every per-row vault encryption used `AesGcm.encrypt(...)` with **no AAD**.
+That makes the ciphertext authenticated against tampering of the bytes
+themselves, but **not** against being moved between rows. A malicious
+or compromised backend can perform a row-swap attack:
+
+```
+DB before:                              DB after server tampering:
+  row A: site_hash=H_bank   payload=P_bank      row A: site_hash=H_bank   payload=P_test
+  row B: site_hash=H_test   payload=P_test      row B: site_hash=H_test   payload=P_bank
+```
+
+GCM authentication passes for both rows (same key, same AAD = empty),
+the user's UI happily renders "bank.com → tEst123!" and ships their
+real bank password to the test domain on next autofill.
+
+**Fix — AAD-bound v2 ciphertext format:**
+
+* `CryptoService.encryptBound(key, plaintext, context)` produces
+  `"v2:" + base64(nonce ‖ ct ‖ tag)` with
+  `AAD = utf8("vault-data:v2:<context>")`.
+* `decryptToBytes` / `decrypt` route on the `v2:` prefix: v2 blobs require
+  the caller-supplied `context` and fail GCM authentication if it
+  doesn't match the value used at encrypt time.  v1 (legacy)
+  ciphertexts continue to decrypt with empty AAD for backwards
+  compatibility.
+* The context for vault entries is derived from the row's `site_hash`,
+  which is `HMAC(masterKey, lower(url))` — a value the server cannot
+  forge:
+  - `payload` blobs ⇒ `"payload:<site_hash>"`
+  - `metadata` blobs ⇒ `"meta:<site_hash>"`
+  - `notes` blobs ⇒ `"notes:<site_hash>"`
+* Account-level seed phrase is bound to the fixed namespace
+  `"account-seed"` for cryptographic domain separation.
+* Any swap by the backend pairs a v2 ciphertext with a different
+  `site_hash` than the one that authenticated it ⇒ AES-GCM tag check
+  fails ⇒ the entry surfaces as `(encrypted)` in the UI rather than
+  silently displaying the wrong row's data.
+* `_v2Prefix` is the literal string `v2:`. The `:` byte is outside the
+  base64 alphabet (`A-Za-z0-9+/=`), so v1 base64 strings can never
+  collide with the v2 prefix — autodetect is unambiguous.
+* Refusing to decrypt a v2 blob without a context throws
+  `StateError` rather than silently downgrading to empty AAD, removing
+  the most obvious foot-gun.
+
+All call-sites — list view (`passwords_screen.dart`), detail view
+(`password_detail_screen.dart`), edit view (`edit_password_screen.dart`),
+and the import path — now thread `site_hash` through to the decrypt
+methods. New writes (add / update / import) emit v2 unconditionally;
+existing v1 vault data continues to decrypt and is implicitly upgraded
+on the next edit.
+
+---
+
+## R3 — KDF iteration downgrade defence
+
+**File:** `lib/services/crypto_service.dart`
+
+The v1 round of fixes added a per-user `kdf_iterations` field returned
+by the server. That introduced a new attack surface: a malicious server
+(or anyone in the TLS path post-cert-pinning failure) could tell a
+*registering* client to use a tiny iteration count — say 1 000 — and
+then offline-brute the resulting weak vault key from a stolen DB dump.
+
+**Fix:** `CryptoService` now enforces a hard floor of
+`minAcceptableKdfIterations = 100 000`. Any server-supplied value below
+that is rejected by `_validateIterations` with an explicit
+`KDF downgrade rejected` error. The floor is intentionally the legacy
+value (rather than the new 600 k default) so existing accounts continue
+to unlock; new registrations get 600 k from `create_user()` and are
+upgraded on master-password change for legacy accounts.
+
+---
+
+## Architectural items reviewed and confirmed safe
+
+| Concern (from the 2026 checklist)                  | Status |
+|----------------------------------------------------|--------|
+| Sharing flow re-encrypts plaintext with ephemeral AES key, sender transmits key OOB; server stores only opaque ciphertext (`server/models.py::PasswordShare`). Server cannot decrypt or substitute the share key. | OK — but see follow-up on key authentication below |
+| Emergency-access vault snapshot uses an ephemeral share key, encrypted client-side; server stores only ciphertext. | OK |
+| Site-hash blind index is keyed (HMAC under master key), not just a plain hash — server cannot enumerate or correlate URLs across users. | OK |
+| Argon2id server-side hash params (`m=128MB, t=4, p=2`) exceed OWASP 2024 minimums; no PBKDF2 fallback in the verify path. | OK (after v1 unification) |
+| Vault metadata leakage: server sees `(user_id, count, timestamps, site_hash)` — irreducible without per-user padding/PIR. Acceptable for the threat model; documented for users. | OK |
+| Master password never crosses the network — only PBKDF2-derived material is used to wrap the vault. | OK |
+| Refresh tokens stored as SHA-256 hashes with `compare_digest`; tokens carry a UUID prefix for `O(1)` revocation. | OK |
+| OTP / MFA replay protected by atomic DB UniqueConstraint inserts. | OK |
+
+---
+
+## Round-2 follow-up items (non-blocking)
+
+1. **Public-key authentication for sharing.** Today the share key travels
+   out-of-band and the recipient's identity is asserted by login string.
+   A signed-share scheme (sender signs the share blob with an account
+   long-term key, recipient verifies) would close the residual
+   "server tells Mallory she's Bob" gap. Requires a new
+   `User.share_pubkey` column and a TOFU prompt in the UI.
+2. **Server-issued `kdf_min_iterations` policy header** — letting the
+   server *raise* the floor for an org without breaking individual
+   downgrade defence, by signalling a minimum which the client compares
+   to its hard-coded floor.
+3. **Vault re-encryption job** for pre-v2 entries when the user changes
+   their master password (already a planned migration; v2 just adds the
+   AAD step).
+4. **Wipe the `SEED_PHRASE_KEY` env var** from production once all known
+   legacy rows have been re-enrolled. The codebase no longer reads it.
+
+---
+
+## Round-2 files changed
+
+```
+server/main.py                   reject plaintext seed_phrase, refuse
+                                 server-decrypt for legacy blobs
+server/utils.py                  drop EncryptionService (key escrow class)
+lib/services/crypto_service.dart encryptBound/decryptBound, v2: prefix,
+                                 KDF iteration floor enforcement
+lib/services/vault_service.dart  thread site_hash AAD context through
+                                 all encrypt/decrypt paths, account-seed
+                                 namespace, decryptNotesSecure
+lib/screens/password_detail_screen.dart  pass _siteHash into decrypts
+lib/screens/edit_password_screen.dart    pass siteHash into decrypts
+lib/screens/passwords_screen.dart        pass siteHash into _copyPassword
+docs/SECURITY_AUDIT.md           this addendum
 ```

--- a/lib/screens/edit_password_screen.dart
+++ b/lib/screens/edit_password_screen.dart
@@ -104,15 +104,22 @@ class _EditPasswordScreenState extends State<EditPasswordScreen> {
       final encPayload = widget.password['encrypted_payload'] as String?;
       final encNotes   = widget.password['notes_encrypted']   as String?;
       final encMeta    = widget.password['encrypted_metadata'] as String?;
+      final siteHash   = widget.password['site_hash'] as String?;
 
       if (encPayload != null) {
-        passwordController.text = await VaultService().decryptPayload(encPayload);
+        passwordController.text =
+            await VaultService().decryptPayload(encPayload, siteHash: siteHash);
       }
       if (encNotes != null) {
-        notesController.text = await VaultService().decryptPayload(encNotes);
+        // Notes use the 'notes:<siteHash>' AAD context, not the payload one.
+        final buf = await VaultService().decryptNotesSecure(encNotes, siteHash: siteHash);
+        final bytes = buf.getBytesCopy();
+        notesController.text = String.fromCharCodes(bytes);
+        bytes.fillRange(0, bytes.length, 0);
+        buf.wipe();
       }
       final decryptedSeed =
-          await VaultService().decryptSeedPhraseFromMetadata(encMeta);
+          await VaultService().decryptSeedPhraseFromMetadata(encMeta, siteHash: siteHash);
       if (decryptedSeed != null) {
         seedPhraseController.text = decryptedSeed;
         unawaited(nativeWipe(decryptedSeed));

--- a/lib/screens/password_detail_screen.dart
+++ b/lib/screens/password_detail_screen.dart
@@ -32,6 +32,7 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
   String? _encryptedPayload;
   String? _encryptedNotes;
   String? _encryptedMetadata;
+  String? _siteHash;  // for v2 AAD binding on decrypt
 
   String _pwdDisplay = '';
   String _notesDisplay = '';
@@ -67,6 +68,7 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
       _encryptedPayload = full['encrypted_payload'] as String?;
       _encryptedNotes = full['notes_encrypted'] as String?;
       _encryptedMetadata = full['encrypted_metadata'] as String?;
+      _siteHash = full['site_hash'] as String?;
     } catch (e) {
       _errorMsg = 'Ошибка расшифровки: $e';
     } finally {
@@ -93,7 +95,7 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
   Future<void> _copyPassword() async {
     if (_encryptedPayload == null || _encryptedPayload!.isEmpty) return;
 
-    final passwordBuf = await VaultService().decryptPayloadSecure(_encryptedPayload!);
+    final passwordBuf = await VaultService().decryptPayloadSecure(_encryptedPayload!, siteHash: _siteHash);
     try {
       await copySecureBuffer(passwordBuf);
     } finally {
@@ -121,7 +123,7 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
     if (_encryptedPayload == null || _encryptedPayload!.isEmpty) return;
 
     try {
-      final passwordBuf = await VaultService().decryptPayloadSecure(_encryptedPayload!);
+      final passwordBuf = await VaultService().decryptPayloadSecure(_encryptedPayload!, siteHash: _siteHash);
       final bytes = passwordBuf.getBytesCopy();
       final display = String.fromCharCodes(bytes);
       bytes.fillRange(0, bytes.length, 0);
@@ -157,7 +159,7 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
     if (_encryptedNotes == null || _encryptedNotes!.isEmpty) return;
 
     try {
-      final notesBuf = await VaultService().decryptPayloadSecure(_encryptedNotes!);
+      final notesBuf = await VaultService().decryptNotesSecure(_encryptedNotes!, siteHash: _siteHash);
       final bytes = notesBuf.getBytesCopy();
       final display = String.fromCharCodes(bytes);
       bytes.fillRange(0, bytes.length, 0);
@@ -194,7 +196,7 @@ class _PasswordDetailScreenState extends State<PasswordDetailScreen> {
 
     try {
       final seedBuf =
-          await VaultService().decryptSeedPhraseFromMetadataSecure(_encryptedMetadata!);
+          await VaultService().decryptSeedPhraseFromMetadataSecure(_encryptedMetadata!, siteHash: _siteHash);
       if (seedBuf == null) return;
 
       final bytes = seedBuf.getBytesCopy();

--- a/lib/screens/passwords_screen.dart
+++ b/lib/screens/passwords_screen.dart
@@ -368,11 +368,11 @@ class _PasswordsScreenState extends State<PasswordsScreen> with RouteAware {
 
   // ── clipboard helpers ───────────────────────────────────────────────────────
 
-  Future<void> _copyPassword(String? encryptedPayload) async {
+  Future<void> _copyPassword(String? encryptedPayload, {String? siteHash}) async {
     if (encryptedPayload == null || encryptedPayload.isEmpty) return;
 
     try {
-      final buf = await VaultService().decryptPayloadSecure(encryptedPayload);
+      final buf = await VaultService().decryptPayloadSecure(encryptedPayload, siteHash: siteHash);
       await copySecureBuffer(buf);
 
       if (mounted) {
@@ -1515,7 +1515,7 @@ class _PasswordsScreenState extends State<PasswordsScreen> with RouteAware {
                   style: TextStyle(color: AppColors.text, fontSize: 15)),
               onTap: () {
                 Navigator.pop(ctx);
-                _copyPassword(item['encrypted_payload'] ?? '');
+                _copyPassword(item['encrypted_payload'] ?? '', siteHash: item['site_hash'] as String?);
               },
             ),
             const SizedBox(height: 8),
@@ -1762,7 +1762,7 @@ class _PasswordsScreenState extends State<PasswordsScreen> with RouteAware {
                       ),
                       IconButton(
                         icon: Icon(Icons.copy, color: AppColors.button),
-                        onPressed: () => _copyPassword(item['encrypted_payload'] ?? ''),
+                        onPressed: () => _copyPassword(item['encrypted_payload'] ?? '', siteHash: item['site_hash'] as String?),
                         tooltip: 'Копировать пароль',
                       ),
                     ],

--- a/lib/services/crypto_service.dart
+++ b/lib/services/crypto_service.dart
@@ -12,10 +12,26 @@ class CryptoService {
 
   /// OWASP 2023+ recommended minimum for PBKDF2-HMAC-SHA256.
   /// Bitwarden uses 600 000 since 2023; we match that as the new default.
-  /// Legacy vaults registered with 100 000 must pass `iterations: 100000`
-  /// explicitly until they re-derive on master-password change.
   static const int defaultKdfIterations = 600000;
+
+  /// Lower bound for legacy vaults registered before the 600k upgrade.
+  /// Any value LOWER than this is rejected — without a floor, a malicious
+  /// backend could downgrade a registering client to e.g. 1 000 iterations
+  /// and offline-brute the resulting weak vault key. The floor is enforced
+  /// client-side because the server is the very party we don't trust here.
   static const int legacyKdfIterations = 100000;
+  static const int minAcceptableKdfIterations = 100000;
+
+  static int _validateIterations(int iterations) {
+    if (iterations < minAcceptableKdfIterations) {
+      throw ArgumentError(
+        'KDF downgrade rejected: iterations=$iterations is below the '
+        'client floor ($minAcceptableKdfIterations). The server may be '
+        'compromised — refusing to derive a weak vault key.',
+      );
+    }
+    return iterations;
+  }
 
   /// Derives a 256-bit key from a master password and salt using PBKDF2-SHA256.
   /// `iterations` MUST match the value used at registration time
@@ -28,7 +44,7 @@ class CryptoService {
     final salt = base64.decode(saltB64);
     final pbkdf2 = Pbkdf2(
       macAlgorithm: Hmac.sha256(),
-      iterations: iterations,
+      iterations: _validateIterations(iterations),
       bits: 256,
     );
     return await pbkdf2.deriveKeyFromPassword(password: password, nonce: salt);
@@ -43,7 +59,7 @@ class CryptoService {
     final salt = base64.decode(saltB64);
     final pbkdf2 = Pbkdf2(
       macAlgorithm: Hmac.sha256(),
-      iterations: iterations,
+      iterations: _validateIterations(iterations),
       bits: 256,
     );
     return await pbkdf2.deriveKey(secretKey: SecretKey(passwordBytes), nonce: salt);
@@ -59,8 +75,58 @@ class CryptoService {
     return base64.encode(mac.bytes);
   }
 
-  /// Encrypts data using AES-GCM.
-  /// Returns base64(nonce + ciphertext + tag).
+  // ── AAD-bound AES-GCM (v2) ─────────────────────────────────────────────────
+  //
+  // Threat model: a malicious or compromised backend can swap fields between
+  // a user's records (e.g. paste record A's encrypted_payload onto record B's
+  // row). Plain AES-GCM with a constant or empty AAD does not bind a
+  // ciphertext to its row context, so the swap decrypts cleanly and the user
+  // sees the wrong password.
+  //
+  // v2 binds each ciphertext to a per-record context (typically derived from
+  // the site_hash, which the server cannot forge — it's an HMAC under the
+  // master key). A v2 blob is tagged with the literal prefix `v2:` so it is
+  // unambiguously distinguishable from a v1 base64 string (`:` is never
+  // produced by base64). Reads transparently fall back to v1 for legacy data.
+
+  static const String _v2Prefix = 'v2:';
+
+  List<int> _aadFor(String context) =>
+      utf8.encode('vault-data:v2:$context');
+
+  /// Encrypts [plaintext] under [key] and binds the ciphertext to [context]
+  /// (e.g. `'payload:' + siteHash`). The result is prefixed with `v2:` so
+  /// readers can route to bound decryption automatically.
+  Future<String> encryptBound(
+    SecretKey key,
+    String plaintext,
+    String context,
+  ) async {
+    final clearText = utf8.encode(plaintext);
+    final secretBox = await _aesGcm.encrypt(
+      clearText,
+      secretKey: key,
+      aad: _aadFor(context),
+    );
+
+    final combined = Uint8List(
+      secretBox.nonce.length +
+          secretBox.cipherText.length +
+          secretBox.mac.bytes.length,
+    );
+    int offset = 0;
+    combined.setAll(offset, secretBox.nonce);
+    offset += secretBox.nonce.length;
+    combined.setAll(offset, secretBox.cipherText);
+    offset += secretBox.cipherText.length;
+    combined.setAll(offset, secretBox.mac.bytes);
+
+    return _v2Prefix + base64.encode(combined);
+  }
+
+  /// Encrypts data using AES-GCM. Legacy (v1) format with empty AAD.
+  /// Returns base64(nonce + ciphertext + tag). Used for shared/ephemeral
+  /// blobs that have no stable record context to bind to.
   Future<String> encrypt(SecretKey key, String plaintext) async {
     final clearText = utf8.encode(plaintext);
     final secretBox = await _aesGcm.encrypt(clearText, secretKey: key);
@@ -83,31 +149,61 @@ class CryptoService {
     return base64.encode(combined);
   }
 
-  /// Decrypts data from base64(nonce + ciphertext + tag).
-  Future<Uint8List> decryptToBytes(SecretKey key, String encryptedB64) async {
+  /// Internal raw GCM open. Accepts either the legacy `base64(...)` form or a
+  /// `v2:` prefixed bound form; for v2 the caller MUST supply the same
+  /// context that was used at encrypt time, otherwise the GCM tag check
+  /// fails — exactly what we want when the backend tries to swap rows.
+  Future<Uint8List> _openGcm(
+    SecretKey key,
+    String encryptedB64,
+    List<int>? aad,
+  ) async {
     final data = base64.decode(encryptedB64);
-
-    // AesGcm uses 12-byte nonce and 16-byte MAC (tag)
     const nonceLen = 12;
     const macLen = 16;
-
     if (data.length < nonceLen + macLen) {
-      throw Exception("Invalid encrypted data length");
+      throw Exception('Invalid encrypted data length');
     }
-
     final nonce = data.sublist(0, nonceLen);
     final ciphertext = data.sublist(nonceLen, data.length - macLen);
     final macBytes = data.sublist(data.length - macLen);
-
     final secretBox = SecretBox(ciphertext, nonce: nonce, mac: Mac(macBytes));
-
-    final clearText = await _aesGcm.decrypt(secretBox, secretKey: key);
+    final clearText = await _aesGcm.decrypt(
+      secretBox,
+      secretKey: key,
+      aad: aad ?? const <int>[],
+    );
     return Uint8List.fromList(clearText);
   }
 
-  /// Decrypts data from base64(nonce + ciphertext + tag).
-  Future<String> decrypt(SecretKey key, String encryptedB64) async {
-    final clearText = await decryptToBytes(key, encryptedB64);
+  /// Decrypts data, auto-detecting v1 vs v2.
+  /// For v2 ciphertexts, [context] MUST be supplied and match the value used
+  /// at encrypt time. For v1 ciphertexts (legacy), [context] is ignored.
+  Future<Uint8List> decryptToBytes(
+    SecretKey key,
+    String encryptedB64, {
+    String? context,
+  }) async {
+    if (encryptedB64.startsWith(_v2Prefix)) {
+      if (context == null) {
+        throw StateError(
+          'v2 ciphertext requires a binding context — refusing to decrypt '
+          'without it (this would silently degrade authentication).',
+        );
+      }
+      return _openGcm(key, encryptedB64.substring(_v2Prefix.length),
+          _aadFor(context));
+    }
+    return _openGcm(key, encryptedB64, null);
+  }
+
+  /// Decrypts to UTF-8 String; see [decryptToBytes] for [context] semantics.
+  Future<String> decrypt(
+    SecretKey key,
+    String encryptedB64, {
+    String? context,
+  }) async {
+    final clearText = await decryptToBytes(key, encryptedB64, context: context);
     try {
       return utf8.decode(clearText);
     } finally {
@@ -115,20 +211,24 @@ class CryptoService {
     }
   }
 
-  /// Helper for encrypting a full metadata object (site_url, site_login, etc.)
+  /// Encrypts a full metadata object bound to [context] (typically
+  /// `'meta:' + siteHash`). Always emits v2.
   Future<String> encryptMetadata(
     SecretKey key,
-    Map<String, dynamic> metadata,
-  ) async {
-    return await encrypt(key, json.encode(metadata));
+    Map<String, dynamic> metadata, {
+    required String context,
+  }) async {
+    return await encryptBound(key, json.encode(metadata), context);
   }
 
-  /// Helper for decrypting the metadata object.
+  /// Decrypts a metadata object. Auto-detects v1/v2; for v2 [context] is
+  /// required and is checked by GCM.
   Future<Map<String, dynamic>> decryptMetadata(
     SecretKey key,
-    String encryptedB64,
-  ) async {
-    final decrypted = await decrypt(key, encryptedB64);
+    String encryptedB64, {
+    String? context,
+  }) async {
+    final decrypted = await decrypt(key, encryptedB64, context: context);
     return json.decode(decrypted);
   }
 }

--- a/lib/services/vault_service.dart
+++ b/lib/services/vault_service.dart
@@ -319,13 +319,35 @@ class VaultService {
     );
   }
 
+  // ── Per-record AAD binding helpers ───────────────────────────────────────────
+  //
+  // The site_hash is HMAC-SHA256(masterKey, lower(url)) — the server cannot
+  // forge it. Threading it through AAD makes a server-side row-swap fail GCM
+  // authentication. For legacy v1 ciphertexts the context is silently ignored
+  // (CryptoService.decrypt routes by the `v2:` prefix).
+
+  static String _payloadCtx(String siteHash) => 'payload:$siteHash';
+  static String _metaCtx(String siteHash)    => 'meta:$siteHash';
+  static String _notesCtx(String siteHash)   => 'notes:$siteHash';
+
   // ── Payload decryption (on-demand only) ──────────────────────────────────────
 
   /// Decrypts a payload into a [SecureBuffer].
   /// **Caller MUST call [SecureBuffer.wipe] when done with the data.**
-  Future<SecureBuffer> decryptPayloadSecure(String encryptedB64) async {
+  ///
+  /// [siteHash] — pass the row's site_hash for v2 ciphertexts. v1 (legacy)
+  /// ignores it. Omitting it for a v2 blob throws by design — we refuse to
+  /// silently drop the row-binding check.
+  Future<SecureBuffer> decryptPayloadSecure(
+    String encryptedB64, {
+    String? siteHash,
+  }) async {
     if (_masterKey == null) throw Exception('Vault is locked');
-    final plaintextBytes = await _crypto.decryptToBytes(_masterKey!, encryptedB64);
+    final plaintextBytes = await _crypto.decryptToBytes(
+      _masterKey!,
+      encryptedB64,
+      context: siteHash != null ? _payloadCtx(siteHash) : null,
+    );
     try {
       return SecureBuffer.fromBytes(plaintextBytes);
     } finally {
@@ -334,9 +356,34 @@ class VaultService {
   }
 
   /// Decrypts a payload to a plain String (use only for edit/save — not display).
-  Future<String> decryptPayload(String encryptedB64) async {
+  Future<String> decryptPayload(
+    String encryptedB64, {
+    String? siteHash,
+  }) async {
     if (_masterKey == null) throw Exception('Vault is locked');
-    return await _crypto.decrypt(_masterKey!, encryptedB64);
+    return await _crypto.decrypt(
+      _masterKey!,
+      encryptedB64,
+      context: siteHash != null ? _payloadCtx(siteHash) : null,
+    );
+  }
+
+  /// Notes-specific decryption. Same v1/v2 rules as [decryptPayload].
+  Future<SecureBuffer> decryptNotesSecure(
+    String encryptedB64, {
+    String? siteHash,
+  }) async {
+    if (_masterKey == null) throw Exception('Vault is locked');
+    final bytes = await _crypto.decryptToBytes(
+      _masterKey!,
+      encryptedB64,
+      context: siteHash != null ? _notesCtx(siteHash) : null,
+    );
+    try {
+      return SecureBuffer.fromBytes(bytes);
+    } finally {
+      bytes.fillRange(0, bytes.length, 0);
+    }
   }
 
   // ── Write operations ─────────────────────────────────────────────────────────
@@ -363,9 +410,16 @@ class VaultService {
         login: login,
         seedPhrase: normalizedSeed,
       ),
+      context: _metaCtx(siteHash),
     );
-    final encPayload    = await _crypto.encrypt(_masterKey!, password);
-    final encNotes      = notes       != null ? await _crypto.encrypt(_masterKey!, notes)       : null;
+    final encPayload    = await _crypto.encryptBound(
+      _masterKey!,
+      password,
+      _payloadCtx(siteHash),
+    );
+    final encNotes      = notes != null
+        ? await _crypto.encryptBound(_masterKey!, notes, _notesCtx(siteHash))
+        : null;
 
     final response = await ApiService.post(AppConfig.passwordsUrl, body: {
       'site_hash':              siteHash,
@@ -406,9 +460,16 @@ class VaultService {
         login: login,
         seedPhrase: normalizedSeed,
       ),
+      context: _metaCtx(siteHash),
     );
-    final encPayload    = await _crypto.encrypt(_masterKey!, password);
-    final encNotes      = notes       != null ? await _crypto.encrypt(_masterKey!, notes)       : null;
+    final encPayload    = await _crypto.encryptBound(
+      _masterKey!,
+      password,
+      _payloadCtx(siteHash),
+    );
+    final encNotes      = notes != null
+        ? await _crypto.encryptBound(_masterKey!, notes, _notesCtx(siteHash))
+        : null;
 
     final response = await ApiService.put('${AppConfig.passwordsUrl}/$id', body: {
       'site_hash':              siteHash,
@@ -435,14 +496,20 @@ class VaultService {
       final login = entry['username'] ?? '';
       final pwd   = entry['password'] ?? '';
       final name  = url.isNotEmpty ? url : (login.isNotEmpty ? login : 'Imported');
+      final siteHash = await _crypto.computeSiteHash(_masterKey!, url);
 
       items.add({
-        'site_hash':          await _crypto.computeSiteHash(_masterKey!, url),
+        'site_hash':          siteHash,
         'encrypted_metadata': await _crypto.encryptMetadata(
           _masterKey!,
           _buildEncryptedMetadata(name: name, url: url, login: login),
+          context: _metaCtx(siteHash),
         ),
-        'encrypted_payload':  await _crypto.encrypt(_masterKey!, pwd),
+        'encrypted_payload':  await _crypto.encryptBound(
+          _masterKey!,
+          pwd,
+          _payloadCtx(siteHash),
+        ),
         'has_2fa':            false,
         'has_seed_phrase':    false,
       });
@@ -466,9 +533,11 @@ class VaultService {
 
     try {
       if (entry['encrypted_metadata'] != null) {
+        final siteHash = entry['site_hash'] as String?;
         final meta = await _crypto.decryptMetadata(
           _masterKey!,
           entry['encrypted_metadata'] as String,
+          context: siteHash != null ? _metaCtx(siteHash) : null,
         );
         entry['title']    = meta['name']       ?? meta['site_url'] ?? '';
         entry['subtitle'] = meta['site_login'] ?? '';
@@ -477,6 +546,10 @@ class VaultService {
             (meta['seed_phrase'] as String).trim().isNotEmpty;
       }
     } catch (_) {
+      // Decrypt failure here is also the malicious-server-swap signal: a v2
+      // metadata blob that was moved onto a different site_hash row will fail
+      // GCM authentication. We surface a placeholder rather than crash so the
+      // user can still see *which* row is suspect.
       entry['title']    = '(encrypted)';
       entry['subtitle'] = '';
     }
@@ -486,12 +559,17 @@ class VaultService {
   }
 
   Future<SecureBuffer?> decryptSeedPhraseFromMetadataSecure(
-    String? encryptedMetadata,
-  ) async {
+    String? encryptedMetadata, {
+    String? siteHash,
+  }) async {
     if (_masterKey == null) throw Exception('Vault is locked');
     if (encryptedMetadata == null || encryptedMetadata.isEmpty) return null;
 
-    final meta = await _crypto.decryptMetadata(_masterKey!, encryptedMetadata);
+    final meta = await _crypto.decryptMetadata(
+      _masterKey!,
+      encryptedMetadata,
+      context: siteHash != null ? _metaCtx(siteHash) : null,
+    );
     final seedPhrase = meta['seed_phrase'];
     if (seedPhrase is! String || seedPhrase.trim().isEmpty) return null;
     final bytes = Uint8List.fromList(utf8.encode(seedPhrase));
@@ -499,8 +577,14 @@ class VaultService {
     return SecureBuffer.fromBytes(bytes);
   }
 
-  Future<String?> decryptSeedPhraseFromMetadata(String? encryptedMetadata) async {
-    final buffer = await decryptSeedPhraseFromMetadataSecure(encryptedMetadata);
+  Future<String?> decryptSeedPhraseFromMetadata(
+    String? encryptedMetadata, {
+    String? siteHash,
+  }) async {
+    final buffer = await decryptSeedPhraseFromMetadataSecure(
+      encryptedMetadata,
+      siteHash: siteHash,
+    );
     if (buffer == null) return null;
     final bytes = buffer.getBytesCopy();
     try {
@@ -511,14 +595,24 @@ class VaultService {
     }
   }
 
+  // ── Account-level seed phrase (user profile, not per-record) ────────────────
+  // Bound to the `account-seed` namespace to keep it cryptographically
+  // separated from per-record blobs.
+
+  static const String _accountSeedCtx = 'account-seed';
+
   Future<String> encryptAccountSeedPhrase(String phrase) async {
     if (_masterKey == null) throw Exception('Vault is locked');
-    return _crypto.encrypt(_masterKey!, phrase.trim());
+    return _crypto.encryptBound(_masterKey!, phrase.trim(), _accountSeedCtx);
   }
 
   Future<SecureBuffer> decryptAccountSeedPhraseSecure(String encryptedB64) async {
     if (_masterKey == null) throw Exception('Vault is locked');
-    final plaintextBytes = await _crypto.decryptToBytes(_masterKey!, encryptedB64);
+    final plaintextBytes = await _crypto.decryptToBytes(
+      _masterKey!,
+      encryptedB64,
+      context: _accountSeedCtx,
+    );
     try {
       return SecureBuffer.fromBytes(plaintextBytes);
     } finally {

--- a/server/main.py
+++ b/server/main.py
@@ -40,7 +40,7 @@ from .auth.service import verify_hardened_otp
 from .config import settings
 from .database import engine, get_db
 import logging
-from .utils import get_favicon_url, EncryptionService
+from .utils import get_favicon_url
 from .auth.dependencies import get_current_user, get_seed_access_user
 from .middleware import SecurityMiddleware, ProxyHeadersMiddleware
 
@@ -279,23 +279,35 @@ def get_seed_phrase(
     current_user: models.User = Depends(get_seed_access_user),
     db: Session = Depends(get_db)
 ):
-    """Retrieve the client-encrypted seed phrase blob. Requires short-lived token."""
+    """Retrieve the client-encrypted seed phrase blob. Requires short-lived token.
+
+    Zero-knowledge contract: the server stores only the client-side ciphertext.
+    Legacy server-encrypted blobs (pre-zero-knowledge migration) are NOT
+    returned in plaintext anymore — instead we return 409 with a re-enrollment
+    hint, forcing the user to set the seed phrase again from a current client.
+    Returning legacy plaintext via this endpoint would defeat the very
+    "malicious backend" defence we are building.
+    """
     if not current_user.seed_phrase_encrypted:
         raise HTTPException(status_code=404, detail="Seed phrase not set")
 
-    # Access Log
     crud.audit_event(db, current_user.id, "seed_phrase_viewed")
-    
-    # Update last viewed
     current_user.seed_phrase_last_viewed_at = datetime.now(timezone.utc)
     db.commit()
-    
+
     stored_value = current_user.seed_phrase_encrypted
     if stored_value.startswith("client:"):
         return {"seed_phrase_encrypted": stored_value.removeprefix("client:")}
 
-    legacy_plaintext = EncryptionService.decrypt(stored_value)
-    return {"seed_phrase": legacy_plaintext}
+    # Legacy server-encrypted blob — refuse to leak plaintext through the API.
+    raise HTTPException(
+        status_code=409,
+        detail=(
+            "legacy_seed_phrase_format: this account has a pre-zero-knowledge "
+            "seed phrase that the server can decrypt. Please re-set the seed "
+            "phrase from a current client to migrate to client-side encryption."
+        ),
+    )
 
 
 @app.post("/profile/seed-phrase")
@@ -306,25 +318,42 @@ def set_seed_phrase(
     current_user: models.User = Depends(auth_deps.get_current_user),
     db: Session = Depends(get_db)
 ):
-    """Set or rotate the seed phrase. Rotation requires multi-factor proof."""
+    """Set or rotate the seed phrase (zero-knowledge: client-side AES-GCM only).
+
+    Security contract:
+      * The server NEVER receives a plaintext seed phrase. Period.
+      * The legacy `seed_phrase` field is rejected outright; old clients must
+        upgrade. This closes the key-escrow / recovery-bypass class of attacks
+        documented in the 2026 ETH Zurich research on password-manager
+        backends — once the server holds a key that can decrypt user secrets,
+        a single backend compromise unwraps every vault.
+    """
     encrypted_phrase = body.get("seed_phrase_encrypted")
-    new_phrase = body.get("seed_phrase")
-    if not encrypted_phrase and not new_phrase:
+
+    if "seed_phrase" in body and not encrypted_phrase:
+        # Plaintext path is permanently disabled.
+        crud.audit_event(
+            db, current_user.id, "seed_phrase_plaintext_rejected",
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "plaintext_seed_phrase_disallowed: encrypt the seed phrase "
+                "client-side and submit it as 'seed_phrase_encrypted'."
+            ),
+        )
+
+    if not encrypted_phrase:
         raise HTTPException(status_code=400, detail="Seed phrase required")
 
-    # If it's a rotation, we should ideally verify old phrase or password
-    # For now, let's enforce TOTP at least
+    # Rotation requires step-up MFA when 2FA is enabled.
     if current_user.totp_enabled:
         otp = request.headers.get("X-OTP")
         verify_hardened_otp(db, current_user, otp)
 
-    # Encrypt with Server Key
-    if encrypted_phrase:
-        current_user.seed_phrase_encrypted = f"client:{encrypted_phrase}"
-    else:
-        current_user.seed_phrase_encrypted = EncryptionService.encrypt(new_phrase)
+    current_user.seed_phrase_encrypted = f"client:{encrypted_phrase}"
     db.commit()
-    
+
     crud.audit_event(db, current_user.id, "seed_phrase_updated")
     return {"success": True}
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,47 +1,20 @@
-import base64
-import os
 import urllib.parse
 import ipaddress
 from typing import Optional
 
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from fastapi import Request
 
 from .config import settings
 
 
-class EncryptionService:
-    @staticmethod
-    def _get_key() -> bytes:
-        # Ensure key is 32 bytes for AesGcm
-        key_str = settings.SEED_PHRASE_KEY
-        key_bytes = key_str.encode()
-        if len(key_bytes) < 32:
-            return key_bytes.ljust(32, b'\0')
-        return key_bytes[:32]
-
-    @classmethod
-    def encrypt(cls, plaintext: str) -> str:
-        if not plaintext:
-            return ""
-        aesgcm = AESGCM(cls._get_key())
-        nonce = os.urandom(12)
-        ciphertext = aesgcm.encrypt(nonce, plaintext.encode(), None)
-        return base64.b64encode(nonce + ciphertext).decode()
-
-    @classmethod
-    def decrypt(cls, encrypted_b64: str) -> str:
-        if not encrypted_b64:
-            return ""
-        try:
-            data = base64.b64decode(encrypted_b64)
-            nonce = data[:12]
-            ciphertext = data[12:]
-            aesgcm = AESGCM(cls._get_key())
-            decrypted = aesgcm.decrypt(nonce, ciphertext, None)
-            return decrypted.decode()
-        except Exception:
-            return ""
+# NOTE: the legacy `EncryptionService` (server-side seed-phrase encryption)
+# was REMOVED as part of the zero-knowledge audit. The server must not hold
+# a key capable of decrypting user secrets — that's the recovery-bypass
+# anti-pattern flagged by the 2026 ETH Zurich password-manager research.
+# All seed phrases are now stored exclusively as client-encrypted blobs
+# (see /profile/seed-phrase in main.py and the `client:` storage prefix).
+# The SEED_PHRASE_KEY env var is retained only because legacy DB rows from
+# before this migration still exist; they are no longer decrypted server-side.
 
 
 def get_client_ip(request: Request) -> str:


### PR DESCRIPTION
Round 2 of the security audit, focused on architectural / E2E / malicious-backend threats from the 2026 ETH research checklist.

CRITICAL
  * Server-side seed-phrase encryption (key escrow / recovery bypass) removed. /profile/seed-phrase now rejects plaintext bodies outright and refuses to server-decrypt legacy blobs (returns 409 with a re-enrol hint). EncryptionService class deleted from server/utils.py so no code path can reach SEED_PHRASE_KEY any more.

HIGH
  * AES-GCM ciphertexts in the vault now bind to per-record context via AAD ("payload:<site_hash>" / "meta:<site_hash>" / "notes:<site_hash>"). A v2: prefix tags new-format blobs; legacy v1 blobs continue to decrypt with empty AAD for backwards compatibility. Refusing to decrypt v2 without a context throws — no silent downgrade. This closes the malicious-backend row-swap attack: any swap by the server pairs a ciphertext with a different site_hash than the one that authenticated it, and GCM tag verification fails.

MEDIUM
  * Client now enforces a hard floor of 100 000 PBKDF2 iterations (CryptoService.minAcceptableKdfIterations). A malicious server can no longer downgrade a registering client to a trivially brute-able iteration count. The legacy floor was chosen so existing accounts keep unlocking; new registrations get 600 000.

Also:
  * Account-level seed phrase moved to the bound 'account-seed' AAD namespace (cryptographic domain separation from per-record blobs).
  * decryptNotesSecure helper added so notes use their own AAD context.
  * All call-sites (passwords_screen, password_detail_screen, edit_password_screen) thread site_hash through to the decrypt methods.

See docs/SECURITY_AUDIT.md "Round 2" for the full report including the items reviewed and confirmed safe (sharing flow, emergency access, metadata leakage budget) and follow-up work for public-key share auth.

https://claude.ai/code/session_01TnnbXj4NqgHqALLwbHP2nq