### PR TITLE
Harden 2FA enrollment response: hide TOTP secret outside development

### DIFF
--- a/server/auth/router.py
+++ b/server/auth/router.py
@@ -148,13 +148,17 @@ def register(
 
     audit(db, new_user.id, "register")
 
+    # Do not expose raw TOTP secret outside local development:
+    # leaking this value enables account takeover by anyone who captures traffic/logs.
+    response_totp_secret = secret if settings.ENVIRONMENT == "development" else None
+
     return UserResponse(
         id=new_user.id,
         login=new_user.login,
         salt=new_user.salt,
         kdf_iterations=new_user.kdf_iterations,
         totp_uri=totp_uri,
-        totp_secret=secret,
+        totp_secret=response_totp_secret,
         access_token=enrollment_token,
     )
 


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of the raw TOTP seed in `/register` responses which could enable account takeover if responses are logged, proxied, or intercepted.

### Description
- Stop returning the raw `totp_secret` in the `/register` response unless `ENVIRONMENT == "development"`, and add a security comment explaining the risk.

### Testing
- Ran the auth-focused test subset with `pytest -q server/tests/test_auth.py -k "register or 2fa or logout"` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a2e6cda883259bee1a989a221edb)