### PR TITLE
Hide TOTP bootstrap outside dev and add constant-time responses for 2FA flows

### DIFF
--- a/server/auth/router.py
+++ b/server/auth/router.py
@@ -148,13 +148,17 @@ def register(
 
     audit(db, new_user.id, "register")
 
+    # Do not expose TOTP enrollment material outside local development:
+    # both `totp_secret` and `totp_uri` contain the same seed and leakage enables account takeover.
+    expose_totp_bootstrap = settings.ENVIRONMENT == "development"
+
     return UserResponse(
         id=new_user.id,
         login=new_user.login,
         salt=new_user.salt,
         kdf_iterations=new_user.kdf_iterations,
-        totp_uri=totp_uri,
-        totp_secret=secret,
+        totp_uri=totp_uri if expose_totp_bootstrap else None,
+        totp_secret=secret if expose_totp_bootstrap else None,
         access_token=enrollment_token,
     )
 
@@ -290,6 +294,7 @@ async def setup_2fa(
     if current_user.totp_enabled:
         log_security_event(db, current_user.id, "2fa_setup_attempt", 
             {"status": "already_enabled"}, None)
+        constant_time_response(start_time)
         raise HTTPException(
             status_code=400,
             detail="2FA is already enabled"
@@ -435,6 +440,7 @@ async def confirm_2fa(
     # verify_hardened_otp skips when totp_enabled=False, so for the
     # enrollment step we verify the code directly against the stored secret.
     if not current_user.totp_secret:
+        constant_time_response(start_time)
         raise HTTPException(status_code=400, detail="2FA not set up. Call /setup_2fa first.")
     try:
         totp_secret = decrypt_totp(current_user.totp_secret, current_user.id)
@@ -725,12 +731,15 @@ async def verify_totp_for_seed(
     db: Session = Depends(get_db),
 ):
     """Verify TOTP for obtaining a short-lived token for sensitive operations (Seed Phrase)."""
+    start_time = time.time()
     otp = request.headers.get("X-OTP")
     if not otp:
+        constant_time_response(start_time)
         raise HTTPException(status_code=400, detail="OTP code is required in X-OTP header")
 
     verify_hardened_otp(db, current_user, otp)
     seed_access_token = create_short_token(current_user.id)
+    constant_time_response(start_time)
     return {"seed_access_token": seed_access_token}
 
 

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -55,6 +55,16 @@ class TestRegister:
         assert "salt" in data and data["salt"]
         assert "id" in data
 
+    def test_register_hides_totp_bootstrap_in_production(self, client):
+        with patch("server.auth.router.settings") as mock_settings:
+            mock_settings.ENVIRONMENT = "production"
+            r = _register(client, login="prod-user")
+
+        assert r.status_code == 201
+        data = r.json()
+        assert data.get("totp_uri") is None
+        assert data.get("totp_secret") is None
+
     def test_duplicate_login_returns_400(self, client):
         _register(client)
         r = _register(client)


### PR DESCRIPTION
### Motivation

- Prevent accidental leakage of TOTP enrollment material (`totp_secret` / `totp_uri`) which can enable account takeover when exposed outside development. 
- Reduce information leakage via timing differences during 2FA-related operations by enforcing constant-time responses on failure paths. 

### Description

- Do not include `totp_secret` or `totp_uri` in the `register` response unless `settings.ENVIRONMENT == "development"`. 
- Add `constant_time_response(start_time)` calls to 2FA-related endpoints to normalize response timing in failure or early-exit branches, including `setup_2fa`, `confirm_2fa`, and `verify_totp_for_seed`. 
- Introduce `start_time` measurement in `verify_totp_for_seed` and use it to call `constant_time_response` on error and before returning a token. 
- Add a unit test `test_register_hides_totp_bootstrap_in_production` to verify that TOTP bootstrap material is omitted in production-like settings. 

### Testing

- Ran the auth unit tests including the new `TestRegister::test_register_hides_totp_bootstrap_in_production` using `pytest server/tests/test_auth.py`; the tests passed. 
- Ran the broader authentication test file `server/tests/test_auth.py` to validate unchanged behavior for registration, encryption, and salts; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a2e6cda883259bee1a989a221edb)