### PR TITLE
Hide TOTP bootstrap in production, harden TOTP flows, and add Emergency Access endpoint

### DIFF
--- a/server/auth/router.py
+++ b/server/auth/router.py
@@ -148,13 +148,17 @@ def register(
 
     audit(db, new_user.id, "register")
 
+    # Do not expose TOTP enrollment material outside local development:
+    # both `totp_secret` and `totp_uri` contain the same seed and leakage enables account takeover.
+    expose_totp_bootstrap = settings.ENVIRONMENT == "development"
+
     return UserResponse(
         id=new_user.id,
         login=new_user.login,
         salt=new_user.salt,
         kdf_iterations=new_user.kdf_iterations,
-        totp_uri=totp_uri,
-        totp_secret=secret,
+        totp_uri=totp_uri if expose_totp_bootstrap else None,
+        totp_secret=secret if expose_totp_bootstrap else None,
         access_token=enrollment_token,
     )
 
@@ -290,6 +294,7 @@ async def setup_2fa(
     if current_user.totp_enabled:
         log_security_event(db, current_user.id, "2fa_setup_attempt", 
             {"status": "already_enabled"}, None)
+        constant_time_response(start_time)
         raise HTTPException(
             status_code=400,
             detail="2FA is already enabled"
@@ -435,6 +440,7 @@ async def confirm_2fa(
     # verify_hardened_otp skips when totp_enabled=False, so for the
     # enrollment step we verify the code directly against the stored secret.
     if not current_user.totp_secret:
+        constant_time_response(start_time)
         raise HTTPException(status_code=400, detail="2FA not set up. Call /setup_2fa first.")
     try:
         totp_secret = decrypt_totp(current_user.totp_secret, current_user.id)
@@ -442,12 +448,11 @@ async def confirm_2fa(
         # valid_window=1 → ±30 s drift compensation (NIST 800-63B / RFC 6238)
         valid = totp_obj.verify(body.code, valid_window=1)
         if not valid:
-            now = datetime.utcnow()
-            expected = {str(offset): totp_obj.at(now + timedelta(seconds=offset))
-                        for offset in (-30, 0, 30)}
+            # Never log OTP values (received or expected): logs are frequently
+            # shipped to third-party systems and could be abused for account takeover.
             _log.warning(
-                "confirm_2fa: invalid TOTP for user_id=%s ip=%s | received=%r expected(±30s)=%s",
-                current_user.id, ip_address, body.code, expected,
+                "confirm_2fa: invalid TOTP for user_id=%s ip=%s",
+                current_user.id, ip_address,
             )
             handle_failed_otp_attempt(db, current_user, ip_address)
             log_security_event(db, current_user.id, "2fa_setup_failed",
@@ -725,12 +730,15 @@ async def verify_totp_for_seed(
     db: Session = Depends(get_db),
 ):
     """Verify TOTP for obtaining a short-lived token for sensitive operations (Seed Phrase)."""
+    start_time = time.time()
     otp = request.headers.get("X-OTP")
     if not otp:
+        constant_time_response(start_time)
         raise HTTPException(status_code=400, detail="OTP code is required in X-OTP header")
 
     verify_hardened_otp(db, current_user, otp)
     seed_access_token = create_short_token(current_user.id)
+    constant_time_response(start_time)
     return {"seed_access_token": seed_access_token}
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -40,7 +40,7 @@ from .auth.service import verify_hardened_otp
 from .config import settings
 from .database import engine, get_db
 import logging
-from .utils import get_favicon_url
+from .utils import get_favicon_url, get_client_ip
 from .auth.dependencies import get_current_user, get_seed_access_user
 from .middleware import SecurityMiddleware, ProxyHeadersMiddleware
 
@@ -1067,6 +1067,58 @@ async def revoke_share(
     crud.audit_event(db, current_user.id, "share_revoked",
                      {"share_id": share_id},
                      background_tasks=background_tasks)
+
+
+# ── Emergency access (trusted person) ───────────────────────────────────────
+
+@app.post("/emergency-access", response_model=schemas.EmergencyAccessResponse, status_code=status.HTTP_201_CREATED)
+async def invite_emergency_contact(
+    request: Request,
+    body: schemas.EmergencyInvite,
+    background_tasks: BackgroundTasks,
+    current_user: models.User = Depends(auth_deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Bind a trusted emergency contact. Always requires valid TOTP."""
+    otp = request.headers.get("X-OTP")
+    if not current_user.totp_enabled or not current_user.totp_secret:
+        raise HTTPException(status_code=403, detail="2FA must be enabled to manage emergency contacts")
+    verify_hardened_otp(db, current_user, otp, get_client_ip(request))
+    if not (1 <= body.wait_days <= 30):
+        raise HTTPException(status_code=400, detail="wait_days must be 1-30")
+
+    grantee = db.query(models.User).filter(models.User.login == body.grantee_login).first()
+    if not grantee:
+        raise HTTPException(status_code=404, detail="Recipient not found")
+    if grantee.id == current_user.id:
+        raise HTTPException(status_code=400, detail="Cannot assign yourself")
+
+    existing = db.query(models.EmergencyAccess).filter(
+        models.EmergencyAccess.grantor_id == current_user.id,
+        models.EmergencyAccess.grantee_id == grantee.id,
+        models.EmergencyAccess.status != "revoked",
+    ).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Emergency contact already exists")
+
+    ea = models.EmergencyAccess(
+        grantor_id=current_user.id,
+        grantee_id=grantee.id,
+        wait_days=body.wait_days,
+        status="invited",
+    )
+    db.add(ea)
+    db.commit()
+    db.refresh(ea)
+
+    crud.audit_event(db, current_user.id, "emergency_invited", {"ea_id": ea.id, "grantee_id": grantee.id}, background_tasks=background_tasks)
+    return schemas.EmergencyAccessResponse(
+        id=ea.id, grantor_id=ea.grantor_id, grantee_id=ea.grantee_id,
+        grantor_login=current_user.login, grantee_login=grantee.login,
+        status=ea.status, wait_days=ea.wait_days,
+        last_checkin_at=ea.last_checkin_at, requested_at=ea.requested_at,
+        approved_at=ea.approved_at, created_at=ea.created_at,
+    )
 
 
 if __name__ == "__main__":

--- a/server/models.py
+++ b/server/models.py
@@ -247,3 +247,21 @@ class PasswordShare(Base):
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     owner = relationship("User", foreign_keys=[owner_id])
+
+
+class EmergencyAccess(Base):
+    __tablename__ = "emergency_access"
+
+    id = Column(Integer, primary_key=True, index=True)
+    grantor_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    grantee_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    status = Column(String, nullable=False, default="invited", index=True)
+    wait_days = Column(Integer, nullable=False, default=7)
+    encrypted_vault = Column(String, nullable=True)
+    last_checkin_at = Column(DateTime(timezone=True), nullable=True)
+    requested_at = Column(DateTime(timezone=True), nullable=True)
+    approved_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+    grantor = relationship("User", foreign_keys=[grantor_id])
+    grantee = relationship("User", foreign_keys=[grantee_id])

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -55,6 +55,16 @@ class TestRegister:
         assert "salt" in data and data["salt"]
         assert "id" in data
 
+    def test_register_hides_totp_bootstrap_in_production(self, client):
+        with patch("server.auth.router.settings") as mock_settings:
+            mock_settings.ENVIRONMENT = "production"
+            r = _register(client, login="prod-user")
+
+        assert r.status_code == 201
+        data = r.json()
+        assert data.get("totp_uri") is None
+        assert data.get("totp_secret") is None
+
     def test_duplicate_login_returns_400(self, client):
         _register(client)
         r = _register(client)
@@ -304,3 +314,28 @@ class TestLogout:
 
     def test_logout_requires_auth(self, client):
         assert client.post("/logout").status_code == 401
+
+
+class TestEmergencyAccessHardening:
+    def test_invite_requires_totp_header(self, client, db_session):
+        _register(client, login="owner")
+        _register(client, login="trusted")
+
+        owner = _get_user(db_session, "owner")
+        token = _make_token_for(owner, db_session)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Enable 2FA for owner
+        setup = client.post("/setup_2fa", headers=headers)
+        secret = setup.json()["secret"]
+        code = pyotp.TOTP(secret).now()
+        client.post("/confirm_2fa", json={"code": code}, headers=headers)
+
+        refreshed = _make_token_for(_get_user(db_session, "owner"), db_session)
+        auth_headers = {"Authorization": f"Bearer {refreshed}"}
+
+        missing_otp = client.post("/emergency-access", json={"grantee_login": "trusted", "wait_days": 7}, headers=auth_headers)
+        assert missing_otp.status_code in (401, 403)
+
+        ok = client.post("/emergency-access", json={"grantee_login": "trusted", "wait_days": 7}, headers={**auth_headers, "X-OTP": pyotp.TOTP(secret).now()})
+        assert ok.status_code == 201


### PR DESCRIPTION
### Motivation
- Prevent accidental leakage of TOTP seeds by hiding bootstrap material outside local development and reduce risk of account takeover. 
- Harden authentication endpoints against timing attacks, enumeration, and unsafe logging of OTP values. 
- Add an emergency/trusted-contact mechanism guarded by TOTP so users can bind a trusted grantee for delayed access.

### Description
- Do not expose `totp_uri` or `totp_secret` in the registration response unless `settings.ENVIRONMENT == "development"`. 
- Add constant-time response padding calls (`constant_time_response`) in multiple TOTP-related flows (`/setup_2fa`, `/confirm_2fa`, `/verify-totp`) and remove logging of OTP values and expected codes in `/confirm_2fa`. 
- Import `get_client_ip` and use it where appropriate; ensure hardened OTP verification is used for sensitive operations. 
- Add an `EmergencyAccess` SQLAlchemy model and a new `/emergency-access` POST endpoint that requires valid TOTP, validates parameters, prevents self-assignment and duplicates, persists an invited emergency access record, and emits an audit event. 
- Add tests covering hiding TOTP bootstrap in production and the emergency access invite flow which ensures TOTP is required.

### Testing
- Ran authentication unit tests in `server/tests/test_auth.py`, including `TestRegister.test_register_hides_totp_bootstrap_in_production`, and they passed. 
- Exercised the emergency access flow via `TestEmergencyAccessHardening.test_invite_requires_totp_header` to assert that TOTP is required and that creating an emergency invite returns `201`, and the test passed. 
- Ran the existing auth-related tests to verify no regressions in login, registration and logout flows and all executed tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a2e6cda883259bee1a989a221edb)