### PR TITLE
Security hardening: SSH startup checks, TOTP privacy, constant-time responses, and emergency-access API

### DIFF
--- a/server/auth/router.py
+++ b/server/auth/router.py
@@ -148,13 +148,17 @@ def register(
 
     audit(db, new_user.id, "register")
 
+    # Do not expose TOTP enrollment material outside local development:
+    # both `totp_secret` and `totp_uri` contain the same seed and leakage enables account takeover.
+    expose_totp_bootstrap = settings.ENVIRONMENT == "development"
+
     return UserResponse(
         id=new_user.id,
         login=new_user.login,
         salt=new_user.salt,
         kdf_iterations=new_user.kdf_iterations,
-        totp_uri=totp_uri,
-        totp_secret=secret,
+        totp_uri=totp_uri if expose_totp_bootstrap else None,
+        totp_secret=secret if expose_totp_bootstrap else None,
         access_token=enrollment_token,
     )
 
@@ -290,6 +294,7 @@ async def setup_2fa(
     if current_user.totp_enabled:
         log_security_event(db, current_user.id, "2fa_setup_attempt", 
             {"status": "already_enabled"}, None)
+        constant_time_response(start_time)
         raise HTTPException(
             status_code=400,
             detail="2FA is already enabled"
@@ -435,6 +440,7 @@ async def confirm_2fa(
     # verify_hardened_otp skips when totp_enabled=False, so for the
     # enrollment step we verify the code directly against the stored secret.
     if not current_user.totp_secret:
+        constant_time_response(start_time)
         raise HTTPException(status_code=400, detail="2FA not set up. Call /setup_2fa first.")
     try:
         totp_secret = decrypt_totp(current_user.totp_secret, current_user.id)
@@ -442,12 +448,11 @@ async def confirm_2fa(
         # valid_window=1 → ±30 s drift compensation (NIST 800-63B / RFC 6238)
         valid = totp_obj.verify(body.code, valid_window=1)
         if not valid:
-            now = datetime.utcnow()
-            expected = {str(offset): totp_obj.at(now + timedelta(seconds=offset))
-                        for offset in (-30, 0, 30)}
+            # Never log OTP values (received or expected): logs are frequently
+            # shipped to third-party systems and could be abused for account takeover.
             _log.warning(
-                "confirm_2fa: invalid TOTP for user_id=%s ip=%s | received=%r expected(±30s)=%s",
-                current_user.id, ip_address, body.code, expected,
+                "confirm_2fa: invalid TOTP for user_id=%s ip=%s",
+                current_user.id, ip_address,
             )
             handle_failed_otp_attempt(db, current_user, ip_address)
             log_security_event(db, current_user.id, "2fa_setup_failed",
@@ -725,12 +730,15 @@ async def verify_totp_for_seed(
     db: Session = Depends(get_db),
 ):
     """Verify TOTP for obtaining a short-lived token for sensitive operations (Seed Phrase)."""
+    start_time = time.time()
     otp = request.headers.get("X-OTP")
     if not otp:
+        constant_time_response(start_time)
         raise HTTPException(status_code=400, detail="OTP code is required in X-OTP header")
 
     verify_hardened_otp(db, current_user, otp)
     seed_access_token = create_short_token(current_user.id)
+    constant_time_response(start_time)
     return {"seed_access_token": seed_access_token}
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,7 @@ import time
 import hmac
 from typing import List, Optional
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pyotp
 import webauthn
@@ -23,6 +24,7 @@ from webauthn import (
     options_to_json,
 )
 import random
+import platform
 import asyncio
 from fastapi import Depends, FastAPI, Header, HTTPException, Request, status, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
@@ -40,7 +42,7 @@ from .auth.service import verify_hardened_otp
 from .config import settings
 from .database import engine, get_db
 import logging
-from .utils import get_favicon_url
+from .utils import get_favicon_url, get_client_ip
 from .auth.dependencies import get_current_user, get_seed_access_user
 from .middleware import SecurityMiddleware, ProxyHeadersMiddleware
 
@@ -57,6 +59,62 @@ def validate_base64(data: str) -> bool:
     except Exception:
         return False
 
+
+
+
+def _ssh_password_login_enabled() -> bool:
+    """Return True when OpenSSH password auth appears enabled."""
+    cfg = Path("/etc/ssh/sshd_config")
+    if not cfg.exists():
+        # In production we fail closed if we cannot verify SSH policy.
+        return True
+
+    effective = None
+    for raw in cfg.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and parts[0].lower() == "passwordauthentication":
+            effective = parts[1].lower()
+    # OpenSSH default is often "yes" if unset; fail closed.
+    return effective != "no"
+
+
+def enforce_runtime_security_policy() -> None:
+    """Block unsafe runtime configurations before API startup."""
+    if platform.system().lower() != "linux":
+        raise RuntimeError(
+            "Zero Vault backend is supported only on Linux hosts. "
+            "Windows deployments are not recommended for this server."
+        )
+
+    if settings.ENVIRONMENT == "development":
+        return
+
+    if settings.ENVIRONMENT == "production" and _ssh_password_login_enabled():
+        raise RuntimeError(
+            "Production startup blocked: SSH password login is enabled or not verifiable.\n\n"
+            "Required hardening steps:\n"
+            "1) Generate an SSH key pair on your admin workstation:\n"
+            "   ssh-keygen -t ed25519 -a 64 -C 'admin@your-host'\n"
+            "2) Copy the public key to the server account:\n"
+            "   ssh-copy-id <user>@<server-ip>\n"
+            "   # or append ~/.ssh/id_ed25519.pub to ~/.ssh/authorized_keys manually\n"
+            "3) Test key-based login in a new terminal:\n"
+            "   ssh <user>@<server-ip>\n"
+            "4) Disable password auth in /etc/ssh/sshd_config:\n"
+            "   PasswordAuthentication no\n"
+            "   ChallengeResponseAuthentication no\n"
+            "   UsePAM no\n"
+            "5) Validate SSH config and reload service:\n"
+            "   sudo sshd -t && sudo systemctl reload sshd\n"
+            "6) Keep one active root/admin session while testing to avoid lockout.\n"
+        )
+
+
+# Enforce platform + SSH hardening at import/startup time.
+enforce_runtime_security_policy()
 
 # Initialize database
 models.Base.metadata.create_all(bind=engine)
@@ -1067,6 +1125,58 @@ async def revoke_share(
     crud.audit_event(db, current_user.id, "share_revoked",
                      {"share_id": share_id},
                      background_tasks=background_tasks)
+
+
+# ── Emergency access (trusted person) ───────────────────────────────────────
+
+@app.post("/emergency-access", response_model=schemas.EmergencyAccessResponse, status_code=status.HTTP_201_CREATED)
+async def invite_emergency_contact(
+    request: Request,
+    body: schemas.EmergencyInvite,
+    background_tasks: BackgroundTasks,
+    current_user: models.User = Depends(auth_deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Bind a trusted emergency contact. Always requires valid TOTP."""
+    otp = request.headers.get("X-OTP")
+    if not current_user.totp_enabled or not current_user.totp_secret:
+        raise HTTPException(status_code=403, detail="2FA must be enabled to manage emergency contacts")
+    verify_hardened_otp(db, current_user, otp, get_client_ip(request))
+    if not (1 <= body.wait_days <= 30):
+        raise HTTPException(status_code=400, detail="wait_days must be 1-30")
+
+    grantee = db.query(models.User).filter(models.User.login == body.grantee_login).first()
+    if not grantee:
+        raise HTTPException(status_code=404, detail="Recipient not found")
+    if grantee.id == current_user.id:
+        raise HTTPException(status_code=400, detail="Cannot assign yourself")
+
+    existing = db.query(models.EmergencyAccess).filter(
+        models.EmergencyAccess.grantor_id == current_user.id,
+        models.EmergencyAccess.grantee_id == grantee.id,
+        models.EmergencyAccess.status != "revoked",
+    ).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Emergency contact already exists")
+
+    ea = models.EmergencyAccess(
+        grantor_id=current_user.id,
+        grantee_id=grantee.id,
+        wait_days=body.wait_days,
+        status="invited",
+    )
+    db.add(ea)
+    db.commit()
+    db.refresh(ea)
+
+    crud.audit_event(db, current_user.id, "emergency_invited", {"ea_id": ea.id, "grantee_id": grantee.id}, background_tasks=background_tasks)
+    return schemas.EmergencyAccessResponse(
+        id=ea.id, grantor_id=ea.grantor_id, grantee_id=ea.grantee_id,
+        grantor_login=current_user.login, grantee_login=grantee.login,
+        status=ea.status, wait_days=ea.wait_days,
+        last_checkin_at=ea.last_checkin_at, requested_at=ea.requested_at,
+        approved_at=ea.approved_at, created_at=ea.created_at,
+    )
 
 
 if __name__ == "__main__":

--- a/server/models.py
+++ b/server/models.py
@@ -247,3 +247,21 @@ class PasswordShare(Base):
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     owner = relationship("User", foreign_keys=[owner_id])
+
+
+class EmergencyAccess(Base):
+    __tablename__ = "emergency_access"
+
+    id = Column(Integer, primary_key=True, index=True)
+    grantor_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    grantee_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    status = Column(String, nullable=False, default="invited", index=True)
+    wait_days = Column(Integer, nullable=False, default=7)
+    encrypted_vault = Column(String, nullable=True)
+    last_checkin_at = Column(DateTime(timezone=True), nullable=True)
+    requested_at = Column(DateTime(timezone=True), nullable=True)
+    approved_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+    grantor = relationship("User", foreign_keys=[grantor_id])
+    grantee = relationship("User", foreign_keys=[grantee_id])

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -55,6 +55,16 @@ class TestRegister:
         assert "salt" in data and data["salt"]
         assert "id" in data
 
+    def test_register_hides_totp_bootstrap_in_production(self, client):
+        with patch("server.auth.router.settings") as mock_settings:
+            mock_settings.ENVIRONMENT = "production"
+            r = _register(client, login="prod-user")
+
+        assert r.status_code == 201
+        data = r.json()
+        assert data.get("totp_uri") is None
+        assert data.get("totp_secret") is None
+
     def test_duplicate_login_returns_400(self, client):
         _register(client)
         r = _register(client)
@@ -304,3 +314,28 @@ class TestLogout:
 
     def test_logout_requires_auth(self, client):
         assert client.post("/logout").status_code == 401
+
+
+class TestEmergencyAccessHardening:
+    def test_invite_requires_totp_header(self, client, db_session):
+        _register(client, login="owner")
+        _register(client, login="trusted")
+
+        owner = _get_user(db_session, "owner")
+        token = _make_token_for(owner, db_session)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Enable 2FA for owner
+        setup = client.post("/setup_2fa", headers=headers)
+        secret = setup.json()["secret"]
+        code = pyotp.TOTP(secret).now()
+        client.post("/confirm_2fa", json={"code": code}, headers=headers)
+
+        refreshed = _make_token_for(_get_user(db_session, "owner"), db_session)
+        auth_headers = {"Authorization": f"Bearer {refreshed}"}
+
+        missing_otp = client.post("/emergency-access", json={"grantee_login": "trusted", "wait_days": 7}, headers=auth_headers)
+        assert missing_otp.status_code in (401, 403)
+
+        ok = client.post("/emergency-access", json={"grantee_login": "trusted", "wait_days": 7}, headers={**auth_headers, "X-OTP": pyotp.TOTP(secret).now()})
+        assert ok.status_code == 201

--- a/server/tests/test_security_hardening.py
+++ b/server/tests/test_security_hardening.py
@@ -51,3 +51,20 @@ def test_webauthn_origin_allows_configured_origin():
         headers=[(b"origin", b"http://localhost")],
     )
     assert _get_webauthn_origin(request) == "http://localhost"
+
+
+def test_runtime_policy_blocks_windows(monkeypatch):
+    import server.main as main
+    monkeypatch.setattr(main.platform, "system", lambda: "Windows")
+    with pytest.raises(RuntimeError, match="supported only on Linux"):
+        main.enforce_runtime_security_policy()
+
+
+def test_runtime_policy_blocks_production_with_ssh_password(monkeypatch):
+    import server.main as main
+    monkeypatch.setattr(main.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(main.settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(main, "_ssh_password_login_enabled", lambda: True)
+
+    with pytest.raises(RuntimeError, match="Production startup blocked"):
+        main.enforce_runtime_security_policy()


### PR DESCRIPTION
### Motivation
- Reduce exposure of TOTP bootstrap material and avoid leaking OTP values to logs to prevent account takeover risks. 
- Enforce runtime hardening to prevent unsafe deployments (non-Linux hosts or SSH password auth enabled) in production. 
- Provide a controlled emergency-access flow for trusted contacts while requiring TOTP for sensitive operations. 
- Standardize timing behavior on several auth endpoints to mitigate enumeration and timing attacks.

### Description
- Hide `totp_uri` and `totp_secret` in the registration response unless `settings.ENVIRONMENT == "development"` to avoid leaking enrollment seeds. 
- Add constant-time response calls (`constant_time_response`) on several early-exit paths (`/setup_2fa`, `/confirm_2fa`, `/verify-totp`) and avoid logging OTP values when verification fails. 
- Add `_ssh_password_login_enabled` and `enforce_runtime_security_policy` in `server/main.py` to block startup on non-Linux hosts or when SSH password auth appears enabled in production, and call the policy on import/startup. 
- Add a new `EmergencyAccess` model and an `/emergency-access` endpoint that requires valid TOTP (`X-OTP`) and enforces basic validations around grantee, wait days, and duplicate invites. 
- Import and use `get_client_ip` where needed and apply various small cleanup changes in `main.py` and `auth/router.py` to wire the new checks.

### Testing
- Ran the test suite under `server/tests` (via `pytest`), including the new tests `TestRegister.test_register_hides_totp_bootstrap_in_production`, `TestEmergencyAccessHardening.test_invite_requires_totp_header`, and runtime policy tests in `test_security_hardening.py`, and all tests passed. 
- Existing auth tests (registration, login, logout, TOTP storage) were executed and remained green after changes. 
- Security hardening tests validating platform and SSH-password checks were executed and raised the expected `RuntimeError` in failure cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a2e6cda883259bee1a989a221edb)