### PR TITLE
Security hardening: TOTP enforcement, WebSocket integrity, production startup checks, emergency access, and README env rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Edit `env.prod`:
 
 ```env
 API_BASE_URL=http://YOUR_SERVER_IP:3000
-ENVIRONMENT=prod
+ENVIRONMENT=production
 ```
 
 ---
@@ -264,26 +264,26 @@ ENVIRONMENT=prod
 
 ```bash
 flutter pub get
-flutter build apk --release --dart-define=ENVIRONMENT=prod
+flutter build apk --release --dart-define=ENVIRONMENT=production
 # → build/app/outputs/flutter-apk/app-release.apk
 ```
 
 **Run on connected device / emulator:**
 
 ```bash
-flutter run --dart-define=ENVIRONMENT=prod
+flutter run --dart-define=ENVIRONMENT=production
 ```
 
 **Web:**
 
 ```bash
-flutter build web --release --dart-define=ENVIRONMENT=prod
+flutter build web --release --dart-define=ENVIRONMENT=production
 ```
 
 **iOS** *(requires macOS + Xcode):*
 
 ```bash
-flutter build ios --release --dart-define=ENVIRONMENT=prod
+flutter build ios --release --dart-define=ENVIRONMENT=production
 ```
 
 <br>

--- a/lib/services/ws_service.dart
+++ b/lib/services/ws_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:crypto/crypto.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:web_socket_channel/io.dart';
@@ -63,9 +64,16 @@ class WsService {
       await _subscription?.cancel();
       _subscription = null;
 
+      final ts = (DateTime.now().millisecondsSinceEpoch ~/ 1000).toString();
+      final checksum = sha256.convert(utf8.encode('$token:$ts')).toString();
+
       _channel = IOWebSocketChannel.connect(
         uri,
-        headers: {'Authorization': 'Bearer $token'},
+        headers: {
+          'Authorization': 'Bearer $token',
+          'X-WS-TS': ts,
+          'X-WS-CHECKSUM': checksum,
+        },
       );
 
       _isConnected = true;

--- a/server/auth/router.py
+++ b/server/auth/router.py
@@ -148,13 +148,17 @@ def register(
 
     audit(db, new_user.id, "register")
 
+    # Do not expose TOTP enrollment material outside local development:
+    # both `totp_secret` and `totp_uri` contain the same seed and leakage enables account takeover.
+    expose_totp_bootstrap = settings.ENVIRONMENT == "development"
+
     return UserResponse(
         id=new_user.id,
         login=new_user.login,
         salt=new_user.salt,
         kdf_iterations=new_user.kdf_iterations,
-        totp_uri=totp_uri,
-        totp_secret=secret,
+        totp_uri=totp_uri if expose_totp_bootstrap else None,
+        totp_secret=secret if expose_totp_bootstrap else None,
         access_token=enrollment_token,
     )
 
@@ -290,6 +294,7 @@ async def setup_2fa(
     if current_user.totp_enabled:
         log_security_event(db, current_user.id, "2fa_setup_attempt", 
             {"status": "already_enabled"}, None)
+        constant_time_response(start_time)
         raise HTTPException(
             status_code=400,
             detail="2FA is already enabled"
@@ -435,6 +440,7 @@ async def confirm_2fa(
     # verify_hardened_otp skips when totp_enabled=False, so for the
     # enrollment step we verify the code directly against the stored secret.
     if not current_user.totp_secret:
+        constant_time_response(start_time)
         raise HTTPException(status_code=400, detail="2FA not set up. Call /setup_2fa first.")
     try:
         totp_secret = decrypt_totp(current_user.totp_secret, current_user.id)
@@ -442,12 +448,11 @@ async def confirm_2fa(
         # valid_window=1 → ±30 s drift compensation (NIST 800-63B / RFC 6238)
         valid = totp_obj.verify(body.code, valid_window=1)
         if not valid:
-            now = datetime.utcnow()
-            expected = {str(offset): totp_obj.at(now + timedelta(seconds=offset))
-                        for offset in (-30, 0, 30)}
+            # Never log OTP values (received or expected): logs are frequently
+            # shipped to third-party systems and could be abused for account takeover.
             _log.warning(
-                "confirm_2fa: invalid TOTP for user_id=%s ip=%s | received=%r expected(±30s)=%s",
-                current_user.id, ip_address, body.code, expected,
+                "confirm_2fa: invalid TOTP for user_id=%s ip=%s",
+                current_user.id, ip_address,
             )
             handle_failed_otp_attempt(db, current_user, ip_address)
             log_security_event(db, current_user.id, "2fa_setup_failed",
@@ -725,12 +730,15 @@ async def verify_totp_for_seed(
     db: Session = Depends(get_db),
 ):
     """Verify TOTP for obtaining a short-lived token for sensitive operations (Seed Phrase)."""
+    start_time = time.time()
     otp = request.headers.get("X-OTP")
     if not otp:
+        constant_time_response(start_time)
         raise HTTPException(status_code=400, detail="OTP code is required in X-OTP header")
 
     verify_hardened_otp(db, current_user, otp)
     seed_access_token = create_short_token(current_user.id)
+    constant_time_response(start_time)
     return {"seed_access_token": seed_access_token}
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -3,8 +3,10 @@ import secrets
 import string
 import time
 import hmac
+from hashlib import sha256
 from typing import List, Optional
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pyotp
 import webauthn
@@ -23,6 +25,7 @@ from webauthn import (
     options_to_json,
 )
 import random
+import platform
 import asyncio
 from fastapi import Depends, FastAPI, Header, HTTPException, Request, status, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
@@ -40,7 +43,7 @@ from .auth.service import verify_hardened_otp
 from .config import settings
 from .database import engine, get_db
 import logging
-from .utils import get_favicon_url
+from .utils import get_favicon_url, get_client_ip
 from .auth.dependencies import get_current_user, get_seed_access_user
 from .middleware import SecurityMiddleware, ProxyHeadersMiddleware
 
@@ -57,6 +60,68 @@ def validate_base64(data: str) -> bool:
     except Exception:
         return False
 
+
+def _require_strict_totp(request: Request, current_user: models.User, db: Session) -> None:
+    """Always require TOTP for high-risk endpoints (not configurable)."""
+    otp = request.headers.get("X-OTP")
+    if not current_user.totp_enabled or not current_user.totp_secret:
+        raise HTTPException(status_code=403, detail="2FA must be enabled for this operation")
+    verify_hardened_otp(db, current_user, otp, get_client_ip(request))
+
+
+def _ssh_password_login_enabled() -> bool:
+    """Return True when OpenSSH password auth appears enabled."""
+    cfg = Path("/etc/ssh/sshd_config")
+    if not cfg.exists():
+        # In production we fail closed if we cannot verify SSH policy.
+        return True
+
+    effective = None
+    for raw in cfg.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and parts[0].lower() == "passwordauthentication":
+            effective = parts[1].lower()
+    # OpenSSH default is often "yes" if unset; fail closed.
+    return effective != "no"
+
+
+def enforce_runtime_security_policy() -> None:
+    """Block unsafe runtime configurations before API startup."""
+    if platform.system().lower() != "linux":
+        raise RuntimeError(
+            "Zero Vault backend is supported only on Linux hosts. "
+            "Windows deployments are not recommended for this server."
+        )
+
+    if settings.ENVIRONMENT == "development":
+        return
+
+    if settings.ENVIRONMENT == "production" and _ssh_password_login_enabled():
+        raise RuntimeError(
+            "Production startup blocked: SSH password login is enabled or not verifiable.\n\n"
+            "Required hardening steps:\n"
+            "1) Generate an SSH key pair on your admin workstation:\n"
+            "   ssh-keygen -t ed25519 -a 64 -C 'admin@your-host'\n"
+            "2) Copy the public key to the server account:\n"
+            "   ssh-copy-id <user>@<server-ip>\n"
+            "   # or append ~/.ssh/id_ed25519.pub to ~/.ssh/authorized_keys manually\n"
+            "3) Test key-based login in a new terminal:\n"
+            "   ssh <user>@<server-ip>\n"
+            "4) Disable password auth in /etc/ssh/sshd_config:\n"
+            "   PasswordAuthentication no\n"
+            "   ChallengeResponseAuthentication no\n"
+            "   UsePAM no\n"
+            "5) Validate SSH config and reload service:\n"
+            "   sudo sshd -t && sudo systemctl reload sshd\n"
+            "6) Keep one active root/admin session while testing to avoid lockout.\n"
+        )
+
+
+# Enforce platform + SSH hardening at import/startup time.
+enforce_runtime_security_policy()
 
 # Initialize database
 models.Base.metadata.create_all(bind=engine)
@@ -141,6 +206,34 @@ MAX_PAYLOAD_SIZE = 2 * 1024 * 1024  # 2MB
 
 from fastapi import WebSocket, WebSocketDisconnect
 
+
+def _prod_safe_log(message: str, *args):
+    """Avoid sensitive telemetry in production logs."""
+    if settings.ENVIRONMENT == "production":
+        return
+    logger.info(message, *args)
+
+
+def _verify_ws_request_integrity(websocket: WebSocket, token: str) -> bool:
+    """Reject stale/replayed websocket handshakes using signed timestamp headers."""
+    ts = websocket.headers.get("x-ws-ts")
+    checksum = websocket.headers.get("x-ws-checksum")
+    if not ts or not checksum:
+        return False
+    try:
+        ts_i = int(ts)
+    except ValueError:
+        return False
+
+    now = int(time.time())
+    if abs(now - ts_i) > 45:
+        return False
+
+    payload = f"{token}:{ts_i}".encode()
+    expected = sha256(payload).hexdigest()
+    return hmac.compare_digest(expected, checksum)
+
+
 class ConnectionManager:
     def __init__(self):
         # user_id -> list of websockets to support multiple devices/tabs
@@ -151,13 +244,13 @@ class ConnectionManager:
         if user_id not in self.active_connections:
             self.active_connections[user_id] = []
         self.active_connections[user_id].append(websocket)
-        logger.info(f"WS: User {user_id} connected. Total active sessions for user: {len(self.active_connections[user_id])}")
+        _prod_safe_log("WS: user connected, active_sessions=%s", len(self.active_connections[user_id]))
 
     def disconnect(self, websocket: WebSocket, user_id: int):
         if user_id in self.active_connections:
             if websocket in self.active_connections[user_id]:
                 self.active_connections[user_id].remove(websocket)
-                logger.info(f"WS: User {user_id} session closed. Remaining sessions: {len(self.active_connections[user_id])}")
+                _prod_safe_log("WS: session closed, remaining_sessions=%s", len(self.active_connections[user_id]))
             if not self.active_connections[user_id]:
                 del self.active_connections[user_id]
 
@@ -166,8 +259,9 @@ class ConnectionManager:
         for websocket in connections:
             try:
                 await websocket.send_json(message)
-            except Exception as e:
-                logger.error(f"WS: Failed to send message to user {user_id}: {str(e)}")
+            except Exception:
+                if settings.ENVIRONMENT != "production":
+                    logger.error("WS: message send failed")
 
 manager = ConnectionManager()
 
@@ -177,11 +271,18 @@ async def websocket_device_events(websocket: WebSocket, token: Optional[str] = N
     db: Optional[Session] = None
     try:
         auth_header = websocket.headers.get("authorization")
-        if (token is None or not token) and auth_header and auth_header.lower().startswith("bearer "):
+        if auth_header and auth_header.lower().startswith("bearer "):
             token = auth_header.split(" ", 1)[1].strip()
 
         if not token:
-            logger.warning(f"WS: Rejecting connection from {client_host} - No token")
+            if settings.ENVIRONMENT != "production":
+                logger.warning("WS: Rejecting connection - missing bearer token")
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+
+        if not _verify_ws_request_integrity(websocket, token):
+            if settings.ENVIRONMENT != "production":
+                logger.warning("WS: Rejecting connection - failed integrity check")
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
             return
 
@@ -193,8 +294,9 @@ async def websocket_device_events(websocket: WebSocket, token: Optional[str] = N
         user = auth_deps._resolve_user_from_token(token, db)
         user_id = user.id
 
-    except Exception as e:
-        logger.warning(f"WS: Auth failed for {client_host}: {str(e)}")
+    except Exception:
+        if settings.ENVIRONMENT != "production":
+            logger.warning("WS: Auth failed")
         try:
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         except:
@@ -215,10 +317,12 @@ async def websocket_device_events(websocket: WebSocket, token: Optional[str] = N
     except WebSocketDisconnect:
         # Handled naturally
         pass
-    except Exception as e:
-        logger.error(f"WS: Exception in session for user {user_id}: {type(e).__name__}: {str(e)}")
-    except BaseException as e:
-        logger.error(f"WS: BaseException in session for user {user_id}: {type(e).__name__}: {str(e)}")
+    except Exception:
+        if settings.ENVIRONMENT != "production":
+            logger.error("WS: Session exception")
+    except BaseException:
+        if settings.ENVIRONMENT != "production":
+            logger.error("WS: BaseException in session")
     finally:
         manager.disconnect(websocket, user_id)
 
@@ -439,15 +543,13 @@ def search_passwords(request: Request,
 @app.post("/import-passwords",
           response_model=List[schemas.PasswordResponse],
           status_code=status.HTTP_201_CREATED)
-@limiter.limit("5/minute")
+@limiter.limit("1/day")
 def import_passwords(request: Request,
                     data: schemas.PasswordImport,
                     background_tasks: BackgroundTasks,
                     current_user: models.User = Depends(auth_deps.get_current_user),
                     db: Session = Depends(get_db)):
-    # OTP-Gated if configured
-    if "vault_write" in settings.PERMISSIONS_OTP_LIST:
-        verify_hardened_otp(db, current_user, request.headers.get("X-OTP"), background_tasks=background_tasks)
+    _require_strict_totp(request, current_user, db)
 
     # Sanity check: limit batch size to 500 items to avoid timeouts/OOM
     if len(data.items) > 500:
@@ -914,6 +1016,7 @@ async def create_share(
     The client re-encrypts the payload with an ephemeral key before sending;
     the server never sees the plaintext or the share key.
     """
+    _require_strict_totp(request, current_user, db)
     # Verify recipient exists
     recipient = db.query(models.User).filter(models.User.login == share.recipient_login).first()
     if recipient is None:
@@ -1021,12 +1124,14 @@ async def get_share(
 
 @app.post("/sharing/{share_id}/accept", response_model=schemas.ShareResponse)
 async def accept_share(
+    request: Request,
     share_id: int,
     background_tasks: BackgroundTasks,
     current_user: models.User = Depends(auth_deps.get_current_user),
     db: Session = Depends(get_db),
 ):
     """Mark an incoming share as accepted."""
+    _require_strict_totp(request, current_user, db)
     share = db.query(models.PasswordShare).filter(models.PasswordShare.id == share_id).first()
     if share is None:
         raise HTTPException(status_code=404, detail="Share not found")
@@ -1049,12 +1154,14 @@ async def accept_share(
 
 @app.delete("/sharing/{share_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def revoke_share(
+    request: Request,
     share_id: int,
     background_tasks: BackgroundTasks,
     current_user: models.User = Depends(auth_deps.get_current_user),
     db: Session = Depends(get_db),
 ):
     """Revoke (delete) a share. Only the owner can revoke."""
+    _require_strict_totp(request, current_user, db)
     share = db.query(models.PasswordShare).filter(models.PasswordShare.id == share_id).first()
     if share is None:
         raise HTTPException(status_code=404, detail="Share not found")
@@ -1067,6 +1174,55 @@ async def revoke_share(
     crud.audit_event(db, current_user.id, "share_revoked",
                      {"share_id": share_id},
                      background_tasks=background_tasks)
+
+
+# ── Emergency access (trusted person) ───────────────────────────────────────
+
+@app.post("/emergency-access", response_model=schemas.EmergencyAccessResponse, status_code=status.HTTP_201_CREATED)
+async def invite_emergency_contact(
+    request: Request,
+    body: schemas.EmergencyInvite,
+    background_tasks: BackgroundTasks,
+    current_user: models.User = Depends(auth_deps.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Bind a trusted emergency contact. Always requires valid TOTP."""
+    _require_strict_totp(request, current_user, db)
+    if not (1 <= body.wait_days <= 30):
+        raise HTTPException(status_code=400, detail="wait_days must be 1-30")
+
+    grantee = db.query(models.User).filter(models.User.login == body.grantee_login).first()
+    if not grantee:
+        raise HTTPException(status_code=404, detail="Recipient not found")
+    if grantee.id == current_user.id:
+        raise HTTPException(status_code=400, detail="Cannot assign yourself")
+
+    existing = db.query(models.EmergencyAccess).filter(
+        models.EmergencyAccess.grantor_id == current_user.id,
+        models.EmergencyAccess.grantee_id == grantee.id,
+        models.EmergencyAccess.status != "revoked",
+    ).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Emergency contact already exists")
+
+    ea = models.EmergencyAccess(
+        grantor_id=current_user.id,
+        grantee_id=grantee.id,
+        wait_days=body.wait_days,
+        status="invited",
+    )
+    db.add(ea)
+    db.commit()
+    db.refresh(ea)
+
+    crud.audit_event(db, current_user.id, "emergency_invited", {"ea_id": ea.id, "grantee_id": grantee.id}, background_tasks=background_tasks)
+    return schemas.EmergencyAccessResponse(
+        id=ea.id, grantor_id=ea.grantor_id, grantee_id=ea.grantee_id,
+        grantor_login=current_user.login, grantee_login=grantee.login,
+        status=ea.status, wait_days=ea.wait_days,
+        last_checkin_at=ea.last_checkin_at, requested_at=ea.requested_at,
+        approved_at=ea.approved_at, created_at=ea.created_at,
+    )
 
 
 if __name__ == "__main__":

--- a/server/models.py
+++ b/server/models.py
@@ -247,3 +247,21 @@ class PasswordShare(Base):
     created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     owner = relationship("User", foreign_keys=[owner_id])
+
+
+class EmergencyAccess(Base):
+    __tablename__ = "emergency_access"
+
+    id = Column(Integer, primary_key=True, index=True)
+    grantor_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    grantee_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    status = Column(String, nullable=False, default="invited", index=True)
+    wait_days = Column(Integer, nullable=False, default=7)
+    encrypted_vault = Column(String, nullable=True)
+    last_checkin_at = Column(DateTime(timezone=True), nullable=True)
+    requested_at = Column(DateTime(timezone=True), nullable=True)
+    approved_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+    grantor = relationship("User", foreign_keys=[grantor_id])
+    grantee = relationship("User", foreign_keys=[grantee_id])

--- a/server/tests/test_auth.py
+++ b/server/tests/test_auth.py
@@ -55,6 +55,16 @@ class TestRegister:
         assert "salt" in data and data["salt"]
         assert "id" in data
 
+    def test_register_hides_totp_bootstrap_in_production(self, client):
+        with patch("server.auth.router.settings") as mock_settings:
+            mock_settings.ENVIRONMENT = "production"
+            r = _register(client, login="prod-user")
+
+        assert r.status_code == 201
+        data = r.json()
+        assert data.get("totp_uri") is None
+        assert data.get("totp_secret") is None
+
     def test_duplicate_login_returns_400(self, client):
         _register(client)
         r = _register(client)
@@ -304,3 +314,28 @@ class TestLogout:
 
     def test_logout_requires_auth(self, client):
         assert client.post("/logout").status_code == 401
+
+
+class TestEmergencyAccessHardening:
+    def test_invite_requires_totp_header(self, client, db_session):
+        _register(client, login="owner")
+        _register(client, login="trusted")
+
+        owner = _get_user(db_session, "owner")
+        token = _make_token_for(owner, db_session)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Enable 2FA for owner
+        setup = client.post("/setup_2fa", headers=headers)
+        secret = setup.json()["secret"]
+        code = pyotp.TOTP(secret).now()
+        client.post("/confirm_2fa", json={"code": code}, headers=headers)
+
+        refreshed = _make_token_for(_get_user(db_session, "owner"), db_session)
+        auth_headers = {"Authorization": f"Bearer {refreshed}"}
+
+        missing_otp = client.post("/emergency-access", json={"grantee_login": "trusted", "wait_days": 7}, headers=auth_headers)
+        assert missing_otp.status_code in (401, 403)
+
+        ok = client.post("/emergency-access", json={"grantee_login": "trusted", "wait_days": 7}, headers={**auth_headers, "X-OTP": pyotp.TOTP(secret).now()})
+        assert ok.status_code == 201

--- a/server/tests/test_security_hardening.py
+++ b/server/tests/test_security_hardening.py
@@ -51,3 +51,20 @@ def test_webauthn_origin_allows_configured_origin():
         headers=[(b"origin", b"http://localhost")],
     )
     assert _get_webauthn_origin(request) == "http://localhost"
+
+
+def test_runtime_policy_blocks_windows(monkeypatch):
+    import server.main as main
+    monkeypatch.setattr(main.platform, "system", lambda: "Windows")
+    with pytest.raises(RuntimeError, match="supported only on Linux"):
+        main.enforce_runtime_security_policy()
+
+
+def test_runtime_policy_blocks_production_with_ssh_password(monkeypatch):
+    import server.main as main
+    monkeypatch.setattr(main.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(main.settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(main, "_ssh_password_login_enabled", lambda: True)
+
+    with pytest.raises(RuntimeError, match="Production startup blocked"):
+        main.enforce_runtime_security_policy()


### PR DESCRIPTION
### Motivation
- Reduce information leakage and tighten defaults for production by hiding TOTP bootstrap materials and removing sensitive telemetry from logs.
- Prevent replay/stale WebSocket handshake attempts by adding a signed timestamp check between client and server.
- Enforce runtime security posture by blocking unsupported OSes and refusing to start in production if SSH password auth appears enabled.
- Add stricter OTP gating for high-risk operations and introduce an emergency-access workflow for trusted recovery.

### Description
- Rename the Flutter environment variable value from `prod` to `production` and update README build/run commands accordingly.
- Add a WebSocket client checksum in `lib/services/ws_service.dart` using `sha256` and send `X-WS-TS` and `X-WS-CHECKSUM` headers for handshake integrity checks.
- Implement `_verify_ws_request_integrity`, `_prod_safe_log`, and stricter WebSocket handling in `server/main.py`, including rejecting connections missing integrity headers and reducing sensitive log output in production.
- Add runtime hardening via `enforce_runtime_security_policy()` (blocks non-Linux hosts and enforces SSH password-auth checks in production) and call it at startup.
- Introduce `_require_strict_totp()` and apply it to sensitive endpoints (`/import-passwords`, share create/accept/revoke, `/sharing` flows), and require TOTP for new emergency-access endpoints.
- Add `EmergencyAccess` model and new `/emergency-access` API to invite a trusted emergency contact with TOTP protection and basic validation.
- Harden TOTP handling in `server/auth/router.py` by hiding enrollment secrets in non-development envs, adding constant-time responses, and removing OTP values from logs.
- Relax noisy logging and make WebSocket handlers more production-safe, and reduce import/route duplication; change import rate limiting for `/import-passwords` to `1/day`.
- Tests: add unit tests to validate TOTP bootstrap hiding and emergency access TOTP gating, and add runtime-policy unit tests.

### Testing
- Ran the Python unit tests under `server/tests` with `pytest`, including `test_auth.py` and `test_security_hardening.py`, and all tests in that suite passed.
- Verified the updated README snippets build/run examples are consistent by inspecting the changed commands (no build executed in CI for mobile toolchain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a2e6cda883259bee1a989a221edb)